### PR TITLE
Improve dashboard widget layout responsiveness

### DIFF
--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -70,25 +70,41 @@ class _DashboardScreenState extends State<DashboardScreen> {
             if (statWidgets.isEmpty)
               const Center(child: Text('Aucun widget à afficher.'))
             else
-            // 2. Grille à 2 colonnes occupant toute la hauteur disponible
               Expanded(
-                child: GridView.count(
-                  crossAxisCount: 2,
-                  crossAxisSpacing: 16,
-                  mainAxisSpacing: 16,
-                  childAspectRatio: 1.5,
-                  children: statWidgets.map((w) {
-                    return Card(
-                      elevation: 2,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    int crossAxisCount;
+                    if (constraints.maxWidth < 600) {
+                      crossAxisCount = 1;
+                    } else if (constraints.maxWidth < 900) {
+                      crossAxisCount = 2;
+                    } else {
+                      crossAxisCount = 3;
+                    }
+
+                    return GridView.builder(
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: crossAxisCount,
+                        crossAxisSpacing: 16,
+                        mainAxisSpacing: 16,
+                        childAspectRatio: 1.1,
                       ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: w,
-                      ),
+                      itemCount: statWidgets.length,
+                      itemBuilder: (context, index) {
+                        final w = statWidgets[index];
+                        return Card(
+                          elevation: 2,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(12),
+                            child: w,
+                          ),
+                        );
+                      },
                     );
-                  }).toList(),
+                  },
                 ),
               ),
           ],

--- a/lib/features/dashboard/widgets/project_progress_widget.dart
+++ b/lib/features/dashboard/widgets/project_progress_widget.dart
@@ -113,12 +113,14 @@ style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic),
 }
 
 return ListView.builder(
-padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
-itemCount: _projectsData.length,
-itemBuilder: (context, index) {
-final pd = _projectsData[index];
-return _buildProjectCard(pd, context);
-},
+  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
+  itemCount: _projectsData.length,
+  shrinkWrap: true,
+  physics: const NeverScrollableScrollPhysics(),
+  itemBuilder: (context, index) {
+    final pd = _projectsData[index];
+    return _buildProjectCard(pd, context);
+  },
 );
 }
 


### PR DESCRIPTION
## Summary
- make progress widget list non-scrollable within grid
- make dashboard grid responsive to screen width

## Testing
- `dart format` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f2ea1c4c4832997e3a5801b99d34e