### PR TITLE
Add first name and phone prefix fields for contacts

### DIFF
--- a/lib/plugins/crm/models/contact.dart
+++ b/lib/plugins/crm/models/contact.dart
@@ -4,10 +4,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class Contact {
   /// Identifiant Firestore
   String? id;
-  /// Nom complet du contact
+  /// Nom de famille du contact
   String name;
+  /// Prénom du contact
+  String firstName;
   /// Adresse e-mail
   String email;
+  /// Indicatif téléphonique (ex: +33)
+  String phonePrefix;
   /// Numéro de téléphone (optionnel)
   String? phone;
   /// Date de création dans la base
@@ -16,7 +20,9 @@ class Contact {
   Contact({
     this.id,
     required this.name,
+    required this.firstName,
     required this.email,
+    this.phonePrefix = '+33',
     this.phone,
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
@@ -27,7 +33,9 @@ class Contact {
     return Contact(
       id: doc.id,
       name: data['name'] as String? ?? '',
+      firstName: data['firstName'] as String? ?? '',
       email: data['email'] as String? ?? '',
+      phonePrefix: data['phonePrefix'] as String? ?? '+33',
       phone: data['phone'] as String?,
       createdAt: (data['createdAt'] as Timestamp).toDate(),
     );
@@ -38,7 +46,9 @@ class Contact {
   Map<String, dynamic> toMap() {
     return {
       'name': name,
+      'firstName': firstName,
       'email': email,
+      'phonePrefix': phonePrefix,
       'phone': phone,
       'createdAt': Timestamp.fromDate(createdAt),
     };

--- a/lib/plugins/crm/screens/contact_detail_screen.dart
+++ b/lib/plugins/crm/screens/contact_detail_screen.dart
@@ -66,10 +66,12 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
             Text('Nom : ${_contact!.name}',
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
+            Text('Prénom : ${_contact!.firstName}'),
+            const SizedBox(height: 8),
             Text('Email : ${_contact!.email}'),
             if (_contact!.phone != null && _contact!.phone!.isNotEmpty) ...[
               const SizedBox(height: 8),
-              Text('Téléphone : ${_contact!.phone}'),
+              Text('Téléphone : ${_contact!.phonePrefix} ${_contact!.phone}'),
             ],
             const SizedBox(height: 24),
             ElevatedButton.icon(

--- a/lib/plugins/crm/screens/contact_form_screen.dart
+++ b/lib/plugins/crm/screens/contact_form_screen.dart
@@ -20,8 +20,10 @@ class ContactFormScreen extends StatefulWidget {
 class _ContactFormScreenState extends State<ContactFormScreen> {
   final _formKey = GlobalKey<FormState>();
   final _nameCtrl  = TextEditingController();
+  final _firstNameCtrl = TextEditingController();
   final _emailCtrl = TextEditingController();
   final _phoneCtrl = TextEditingController();
+  String _phonePrefix = '+33';
   bool _loading = false;
 
   bool get _isEditing => widget.contactId != null;
@@ -39,7 +41,9 @@ class _ContactFormScreenState extends State<ContactFormScreen> {
     final contact = await context.read<ContactProvider>().fetchById(widget.contactId!);
     if (contact != null) {
       _nameCtrl.text  = contact.name;
+      _firstNameCtrl.text = contact.firstName;
       _emailCtrl.text = contact.email;
+      _phonePrefix = contact.phonePrefix;
       _phoneCtrl.text = contact.phone ?? '';
     }
     setState(() => _loading = false);
@@ -53,7 +57,9 @@ class _ContactFormScreenState extends State<ContactFormScreen> {
     final contact = Contact(
       id:    widget.contactId,
       name:  _nameCtrl.text.trim(),
+      firstName: _firstNameCtrl.text.trim(),
       email: _emailCtrl.text.trim(),
+      phonePrefix: _phonePrefix,
       phone: _phoneCtrl.text.trim().isEmpty ? null : _phoneCtrl.text.trim(),
     );
 
@@ -74,6 +80,7 @@ class _ContactFormScreenState extends State<ContactFormScreen> {
   @override
   void dispose() {
     _nameCtrl.dispose();
+    _firstNameCtrl.dispose();
     _emailCtrl.dispose();
     _phoneCtrl.dispose();
     super.dispose();
@@ -112,6 +119,11 @@ class _ContactFormScreenState extends State<ContactFormScreen> {
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
+                  controller: _firstNameCtrl,
+                  decoration: const InputDecoration(labelText: 'Prénom'),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
                   controller: _emailCtrl,
                   decoration: const InputDecoration(labelText: 'Email'),
                   keyboardType: TextInputType.emailAddress,
@@ -119,10 +131,24 @@ class _ContactFormScreenState extends State<ContactFormScreen> {
                   (v == null || !v.contains('@')) ? 'Email invalide' : null,
                 ),
                 const SizedBox(height: 16),
-                TextFormField(
-                  controller: _phoneCtrl,
-                  decoration: const InputDecoration(labelText: 'Téléphone'),
-                  keyboardType: TextInputType.phone,
+                Row(
+                  children: [
+                    DropdownButton<String>(
+                      value: _phonePrefix,
+                      onChanged: (v) => setState(() => _phonePrefix = v ?? _phonePrefix),
+                      items: const ['+33', '+596', '+590']
+                          .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                          .toList(),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _phoneCtrl,
+                        decoration: const InputDecoration(labelText: 'Téléphone'),
+                        keyboardType: TextInputType.phone,
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/plugins/crm/screens/contact_list_screen.dart
+++ b/lib/plugins/crm/screens/contact_list_screen.dart
@@ -77,7 +77,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
               itemBuilder: (ctx, i) {
                 final Contact c = prov.contacts[i];
                 return ListTile(
-                  title: Text(c.name),
+                  title: Text('${c.firstName} ${c.name}'),
                   subtitle: Text(c.email),
                   onTap: () => _openPanel(contactId: c.id),
                 );


### PR DESCRIPTION
## Summary
- extend `Contact` model with `firstName` and `phonePrefix`
- show and edit new fields in the contact form
- display first name and phone prefix in contact list and detail screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1be6b048329b417b2162906d1b7