### PR TITLE
Add notification badges and message notifications

### DIFF
--- a/lib/features/chat/data/chat_repository.dart
+++ b/lib/features/chat/data/chat_repository.dart
@@ -65,6 +65,7 @@ class ChatRepository {
         'projectId': conversationId,
         'lastMessage': text,
         'lastMessageTime': now,
+        'lastSenderId': currentUid,
       },
       SetOptions(merge: true),
     );
@@ -111,6 +112,7 @@ class ChatRepository {
         'projectId': conversationId,
         'lastMessage': '[${type.toUpperCase()}]',
         'lastMessageTime': now,
+        'lastSenderId': currentUid,
       },
       SetOptions(merge: true),
     );
@@ -200,6 +202,7 @@ class ChatRepository {
       'participants': [currentUid, otherUid],
       'lastMessage': '',
       'lastMessageTime': FieldValue.serverTimestamp(),
+      'lastSenderId': '',
     });
     return ref.id;
   }

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -14,6 +14,7 @@ class NotificationService {
 
   StreamSubscription<QuerySnapshot>? _incomingReqSub;
   StreamSubscription<QuerySnapshot>? _acceptedReqSub;
+  StreamSubscription<QuerySnapshot>? _messageConvSub;
 
   Future<void> init() async {
     // Initialisation des notifications locales
@@ -23,6 +24,7 @@ class NotificationService {
     );
     _listenFriendRequests();
     _listenFriendAcceptances();
+    _listenMessages();
   }
 
   void _listenFriendRequests() {
@@ -123,8 +125,54 @@ class NotificationService {
     });
   }
 
+  void _listenMessages() {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+
+    _messageConvSub = _firestore
+        .collection('conversations')
+        .where('participants', arrayContains: uid)
+        .snapshots()
+        .listen((snap) {
+      for (var change in snap.docChanges) {
+        if (change.type == DocumentChangeType.modified) {
+          final data = change.doc.data();
+          final sender = data?['lastSenderId'] as String?;
+          final msg = data?['lastMessage'] as String? ?? '';
+          if (sender == null || sender == uid) continue;
+
+          _firestore.collection('notifications').add({
+            'recipientId': uid,
+            'type': 'message',
+            'title': 'Nouveau message',
+            'body': msg,
+            'conversationId': change.doc.id,
+            'timestamp': FieldValue.serverTimestamp(),
+            'read': false,
+          });
+
+          _localNotif.show(
+            2,
+            'Nouveau message',
+            msg,
+            const NotificationDetails(
+              android: AndroidNotificationDetails(
+                'message_channel',
+                'Messages',
+                channelDescription: 'Nouveaux messages',
+                importance: Importance.max,
+                priority: Priority.high,
+              ),
+            ),
+          );
+        }
+      }
+    });
+  }
+
   void dispose() {
     _incomingReqSub?.cancel();
     _acceptedReqSub?.cancel();
+    _messageConvSub?.cancel();
   }
 }

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -17,8 +17,11 @@ import '../../features/notifications/views/notifications_screen.dart';
 import '../../features/library/views/library_screen.dart';
 import '../../features/projects/views/projects_screen.dart';
 import '../../settings/views/settings_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../main.dart'; // Pour AppTheme, themeNotifier et AppColors
+import '../../features/notifications/services/notification_service.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -32,10 +35,18 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _showLabels = false;
   Timer? _labelTimer;
   final ValueNotifier<int> _calendarRefreshNotifier = ValueNotifier<int>(0);
+  final NotificationService _notifService = NotificationService();
+
+  @override
+  void initState() {
+    super.initState();
+    _notifService.init();
+  }
 
   @override
   void dispose() {
     _labelTimer?.cancel();
+    _notifService.dispose();
     super.dispose();
   }
 
@@ -154,21 +165,28 @@ class _HomeScreenState extends State<HomeScreen> {
             const Spacer(),
             // Items fixes en bas
             for (var i = pages.length - 3; i < pages.length; i++)
-              _buildNavItem(
-                iconData: icons[i],
-                label: labels[i],
-                showLabel: _showLabels,
-                isSelected: _selectedIndex == i,
-                selectedBg: selectedBg,
-                onTap: () => setState(() => _selectedIndex = i),
-              ),
+              i == pages.length - 3
+                  ? _buildNotificationsNavItem(
+                      index: i,
+                      iconData: icons[i],
+                      label: labels[i],
+                      selectedBg: selectedBg,
+                    )
+                  : _buildNavItem(
+                      iconData: icons[i],
+                      label: labels[i],
+                      showLabel: _showLabels,
+                      isSelected: _selectedIndex == i,
+                      selectedBg: selectedBg,
+                      onTap: () => setState(() => _selectedIndex = i),
+                    ),
             const SizedBox(height: 24),
           ],
         ),
       ),
     );
 
-    Widget content = Scaffold(
+  Widget content = Scaffold(
       backgroundColor: isSequoia ? Colors.transparent : mainBg,
       body: Row(
         children: [
@@ -193,6 +211,59 @@ class _HomeScreenState extends State<HomeScreen> {
     return content;
   }
 
+  Widget _buildNotificationsNavItem({
+    required int index,
+    required IconData iconData,
+    required String label,
+    required Color selectedBg,
+  }) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return _buildNavItem(
+        iconData: iconData,
+        label: label,
+        showLabel: _showLabels,
+        isSelected: _selectedIndex == index,
+        selectedBg: selectedBg,
+        onTap: () => setState(() => _selectedIndex = index),
+      );
+    }
+
+    final pendingStream = FirebaseFirestore.instance
+        .collection('collaborations')
+        .where('to', isEqualTo: uid)
+        .where('status', isEqualTo: 'pending')
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: pendingStream,
+      builder: (ctx, pendSnap) {
+        final pending = pendSnap.data?.size ?? 0;
+        final notifStream = FirebaseFirestore.instance
+            .collection('notifications')
+            .where('recipientId', isEqualTo: uid)
+            .where('read', isEqualTo: false)
+            .snapshots();
+
+        return StreamBuilder<QuerySnapshot>(
+          stream: notifStream,
+          builder: (ctx2, notifSnap) {
+            final count = (notifSnap.data?.size ?? 0) + pending;
+            return _buildNavItem(
+              iconData: iconData,
+              label: label,
+              showLabel: _showLabels,
+              isSelected: _selectedIndex == index,
+              selectedBg: selectedBg,
+              badgeCount: count > 0 ? count : null,
+              onTap: () => setState(() => _selectedIndex = index),
+            );
+          },
+        );
+      },
+    );
+  }
+
   Widget _buildNavItem({
     required IconData iconData,
     required String label,
@@ -200,6 +271,7 @@ class _HomeScreenState extends State<HomeScreen> {
     required bool isSelected,
     required Color selectedBg,
     required VoidCallback onTap,
+    int? badgeCount,
   }) {
     final color = isSelected
         ? Theme.of(context).colorScheme.primary
@@ -212,7 +284,29 @@ class _HomeScreenState extends State<HomeScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
           child: Row(
             children: [
-              Icon(iconData, size: 24, color: color),
+              Stack(
+                children: [
+                  Icon(iconData, size: 24, color: color),
+                  if (badgeCount != null && badgeCount > 0)
+                    Positioned(
+                      right: 0,
+                      top: 0,
+                      child: Container(
+                        padding: const EdgeInsets.all(2),
+                        decoration: const BoxDecoration(
+                          color: Colors.red,
+                          shape: BoxShape.circle,
+                        ),
+                        constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+                        child: Text(
+                          '$badgeCount',
+                          style: const TextStyle(color: Colors.white, fontSize: 10),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
               if (showLabel) ...[
                 const SizedBox(width: 12),
                 Text(label, style: TextStyle(color: color)),


### PR DESCRIPTION
## Summary
- track message senders in `ChatRepository`
- show unread notification count on sidebar
- listen for new messages in `NotificationService`
- start NotificationService in `HomeScreen`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3eccf7988329a1cfc300d140f47b