### PR TITLE
Add printable quote in CRM

### DIFF
--- a/lib/plugins/crm/screens/quote_detail_screen.dart
+++ b/lib/plugins/crm/screens/quote_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:tokan/main.dart'; // pour AppColors
 import 'package:tokan/plugins/crm/providers/quote_provider.dart';
 import 'package:tokan/plugins/crm/models/quote.dart';
 import 'package:tokan/plugins/crm/screens/quote_form_screen.dart';
+import 'package:tokan/plugins/crm/services/quote_pdf_service.dart';
 
 class QuoteDetailScreen extends StatefulWidget {
   final String quoteId;
@@ -61,6 +62,14 @@ class _QuoteDetailScreenState extends State<QuoteDetailScreen> {
                 builder: (_) => QuoteFormScreen(quoteId: widget.quoteId),
               ),
             ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.print),
+            onPressed: () async {
+              if (_quote != null) {
+                await QuotePdfService().printQuote(_quote!);
+              }
+            },
           ),
           IconButton(
             icon: const Icon(Icons.delete),

--- a/lib/plugins/crm/services/quote_pdf_service.dart
+++ b/lib/plugins/crm/services/quote_pdf_service.dart
@@ -1,0 +1,54 @@
+import 'package:pdf/widgets.dart' as pw;
+import 'package:pdf/pdf.dart';
+import 'package:printing/printing.dart';
+
+import '../models/quote.dart';
+
+class QuotePdfService {
+  Future<pw.Document> buildPdf(Quote quote) async {
+    final doc = pw.Document();
+    doc.addPage(
+      pw.Page(
+        pageFormat: PdfPageFormat.a4,
+        build: (pw.Context context) {
+          return pw.Container(
+            padding: const pw.EdgeInsets.all(32),
+            child: pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                pw.Text('Devis ${quote.reference}',
+                    style: pw.TextStyle(fontSize: 24, fontWeight: pw.FontWeight.bold)),
+                pw.SizedBox(height: 16),
+                if (quote.customer != null && quote.customer!.isNotEmpty)
+                  pw.Text('Client : ${quote.customer!}'),
+                pw.Text('Statut : ${quote.status}'),
+                pw.Text('Créé le : ${quote.createdAt.toLocal()}'),
+                if (quote.dueDate != null)
+                  pw.Text('Échéance : ${quote.dueDate!.toLocal()}'),
+                if (quote.description != null && quote.description!.isNotEmpty) ...[
+                  pw.SizedBox(height: 16),
+                  pw.Text(quote.description!),
+                ],
+                pw.Spacer(),
+                pw.Text('Total : ${quote.total.toStringAsFixed(2)} €',
+                    style: pw.TextStyle(fontSize: 20, fontWeight: pw.FontWeight.bold)),
+                if (quote.discount != null)
+                  pw.Text('Remise : ${quote.discount!.toStringAsFixed(2)}%'),
+                if (quote.notes != null && quote.notes!.isNotEmpty) ...[
+                  pw.SizedBox(height: 16),
+                  pw.Text('Notes : ${quote.notes!}'),
+                ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+    return doc;
+  }
+
+  Future<void> printQuote(Quote quote) async {
+    final doc = await buildPdf(quote);
+    await Printing.layoutPdf(onLayout: (PdfPageFormat format) async => doc.save());
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,10 @@ dependencies:
   share_plus: ^11.0.0
   path_provider: ^2.1.5
 
+  # PDF generation & printing
+  pdf: ^3.10.4
+  printing: ^5.11.0
+
 
 
 


### PR DESCRIPTION
## Summary
- enable PDF generation and printing for CRM quotes
- create `QuotePdfService` for building and printing a PDF document
- allow printing a quote from the detail screen
- add `pdf` and `printing` dependencies

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afcce67488329b67ada1290f98c0a