### PR TITLE
Implement persistent login with FirebaseAuth

### DIFF
--- a/lib/features/auth/views/auth_gate.dart
+++ b/lib/features/auth/views/auth_gate.dart
@@ -1,0 +1,29 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/interface/interface.dart';
+import 'login_screen.dart';
+
+/// Widget qui écoute l'état d'authentification pour
+/// afficher l'écran approprié.
+class AuthGate extends StatelessWidget {
+  const AuthGate({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (snapshot.data == null) {
+          return const LoginPage();
+        }
+        return const HomeScreen();
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'plugins/crm/providers/quote_provider.dart';
 import 'features/auth/services/auth_service.dart';
 import 'features/auth/views/login_screen.dart';
 import 'features/auth/views/register_screen.dart';
+import 'features/auth/views/auth_gate.dart';
 import 'shared/interface/interface.dart'; // Pour HomeScreen
 import 'firebase_options.dart';
 
@@ -219,7 +220,6 @@ class MyApp extends StatelessWidget {
     return ValueListenableBuilder<AppTheme>(
       valueListenable: themeNotifier,
       builder: (context, currentAppTheme, child) {
-        final bool isLoggedIn = FirebaseAuth.instance.currentUser != null;
         ThemeData themeToApply;
         switch (currentAppTheme) {
           case AppTheme.light:
@@ -237,7 +237,7 @@ class MyApp extends StatelessWidget {
           title: 'Mon App',
           debugShowCheckedModeBanner: false,
           theme: themeToApply,
-          home: isLoggedIn ? const HomeScreen() : const LoginPage(),
+          home: const AuthGate(),
           routes: {
             '/login':    (_) => const LoginPage(),
             '/register': (_) => const RegisterPage(),


### PR DESCRIPTION
## Summary
- add an `AuthGate` widget to observe `authStateChanges`
- use the `AuthGate` as the home widget so sessions are restored automatically

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5ea6c47883299329fd58651a82c5