### PR TITLE
Implement task folder feature

### DIFF
--- a/lib/features/tasks/models/custom_task_model.dart
+++ b/lib/features/tasks/models/custom_task_model.dart
@@ -16,6 +16,7 @@ class CustomTask extends Equatable {
   int? duration;         // Durée estimée en minutes
   String? client;        // Nom du client (optionnel)
   String? project;       // Projet d’appartenance (optionnel)
+  String? folderId;      // Dossier auquel la tâche appartient
 
   /// ID du projet avant édition, pour détecter les changements de projet
   String? originalProjectId;
@@ -43,6 +44,7 @@ class CustomTask extends Equatable {
     this.duration,
     this.client,
     this.project,
+    this.folderId,
     this.originalProjectId,
     this.recurrenceType,
     this.recurrenceDays,
@@ -76,6 +78,7 @@ class CustomTask extends Equatable {
       'duration': duration,
       'client': client,
       'project': project,
+      'folderId': folderId,
       // Champs de récurrence
       'recurrenceType': recurrenceType,
       'recurrenceDays': recurrenceDays,
@@ -100,6 +103,7 @@ class CustomTask extends Equatable {
       'duration': duration,
       'client': client,
       'project': project,
+      'folderId': folderId,
       'recurrenceType': recurrenceType,
       'recurrenceDays': recurrenceDays,
       'recurrenceIncludePast': recurrenceIncludePast ?? false,
@@ -170,6 +174,7 @@ class CustomTask extends Equatable {
       duration: map['duration'] as int?,
       client: map['client'] as String?,
       project: proj,
+      folderId: map['folderId'] as String?,
       originalProjectId: proj,
       recurrenceType: map['recurrenceType'] as String?,
       recurrenceDays: _mapToRecurrenceDays(map['recurrenceDays']),
@@ -198,6 +203,7 @@ class CustomTask extends Equatable {
       duration: map['duration'] as int?,
       client: map['client'] as String?,
       project: proj,
+      folderId: map['folderId'] as String?,
       originalProjectId: proj,
       recurrenceType: map['recurrenceType'] as String?,
       recurrenceDays: _mapToRecurrenceDays(map['recurrenceDays']),
@@ -225,6 +231,7 @@ class CustomTask extends Equatable {
     int? duration,
     String? client,
     String? project,
+    String? folderId,
     String? originalProjectId,
     String? recurrenceType,
     List<int>? recurrenceDays,
@@ -243,6 +250,7 @@ class CustomTask extends Equatable {
       duration: duration ?? this.duration,
       client: client ?? this.client,
       project: project ?? this.project,
+      folderId: folderId ?? this.folderId,
       originalProjectId: originalProjectId ?? this.originalProjectId,
       recurrenceType: recurrenceType ?? this.recurrenceType,
       recurrenceDays: recurrenceDays != null ? List<int>.from(recurrenceDays) : this.recurrenceDays,
@@ -266,6 +274,7 @@ class CustomTask extends Equatable {
     duration,
     client,
     project,
+    folderId,
     originalProjectId,
     recurrenceType,
     recurrenceDays,

--- a/lib/features/tasks/models/task_folder_model.dart
+++ b/lib/features/tasks/models/task_folder_model.dart
@@ -1,0 +1,30 @@
+class TaskFolder {
+  String id;
+  String name;
+  String projectId;
+  String? parentId;
+
+  TaskFolder({
+    this.id = '',
+    required this.name,
+    required this.projectId,
+    this.parentId,
+  });
+
+  factory TaskFolder.fromMap(Map<String, dynamic> data, String documentId) {
+    return TaskFolder(
+      id: documentId,
+      name: data['name'] ?? '',
+      projectId: data['projectId'] ?? '',
+      parentId: data['parentId'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'projectId': projectId,
+      'parentId': parentId,
+    };
+  }
+}

--- a/lib/features/tasks/services/task_folder_service.dart
+++ b/lib/features/tasks/services/task_folder_service.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/task_folder_model.dart';
+
+class TaskFolderService {
+  final CollectionReference _collection =
+      FirebaseFirestore.instance.collection('taskFolders');
+
+  Stream<List<TaskFolder>> getFolders(String projectId) {
+    return _collection
+        .where('projectId', isEqualTo: projectId)
+        .snapshots()
+        .map((snap) => snap.docs
+            .map((d) => TaskFolder.fromMap(d.data() as Map<String, dynamic>, d.id))
+            .toList());
+  }
+
+  Future<TaskFolder> createFolder(TaskFolder folder) async {
+    final doc = await _collection.add(folder.toMap());
+    folder.id = doc.id;
+    return folder;
+  }
+
+  Future<void> updateFolder(TaskFolder folder) async {
+    await _collection.doc(folder.id).update(folder.toMap());
+  }
+
+  Future<void> deleteFolder(String id) async {
+    await _collection.doc(id).delete();
+  }
+}

--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -9,6 +9,9 @@ import 'package:intl/intl.dart';
 import '../widgets/task_list_mode_widget.dart';
 import '../widgets/task_calendar_mode_widget.dart';
 
+import '../models/task_folder_model.dart';
+import '../services/task_folder_service.dart';
+
 // Import du panneau de détails de tâche
 import '../../../shared/widgets/task_details_panel_widget.dart';
 
@@ -62,34 +65,58 @@ class _TasksPageState extends State<TasksPage> {
               ),
             ),
 
-          StreamBuilder<List<CustomTask>>(
-            stream: _getTasksStream(),
-            builder: (context, snap) {
-              if (snap.hasError) {
+          StreamBuilder<List<TaskFolder>>(
+            stream: _getFoldersStream(),
+            builder: (context, folderSnap) {
+              if (folderSnap.hasError) {
                 return Center(
                   child: Text(
-                    'Erreur : ${snap.error}',
+                    'Erreur : ${folderSnap.error}',
                     style: TextStyle(
                       color: Theme.of(context).colorScheme.onBackground,
                     ),
                   ),
                 );
               }
-              if (!snap.hasData) {
+              if (!folderSnap.hasData) {
                 return Center(
                   child: CircularProgressIndicator(
                     valueColor:
-                    AlwaysStoppedAnimation<Color>(AppColors.green),
+                        AlwaysStoppedAnimation<Color>(AppColors.green),
                   ),
                 );
               }
-              final tasks = snap.data!;
+              final folders = folderSnap.data!;
 
-              return Column(
-                children: [
-                  _buildHorizontalMenu(tasks),
-                  Expanded(child: _buildView(tasks)),
-                ],
+              return StreamBuilder<List<CustomTask>>(
+                stream: _getTasksStream(),
+                builder: (context, snap) {
+                  if (snap.hasError) {
+                    return Center(
+                      child: Text(
+                        'Erreur : ${snap.error}',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.onBackground,
+                        ),
+                      ),
+                    );
+                  }
+                  if (!snap.hasData) {
+                    return Center(
+                      child: CircularProgressIndicator(
+                        valueColor: AlwaysStoppedAnimation<Color>(AppColors.green),
+                      ),
+                    );
+                  }
+                  final tasks = snap.data!;
+
+                  return Column(
+                    children: [
+                      _buildHorizontalMenu(tasks, folders),
+                      Expanded(child: _buildView(tasks, folders)),
+                    ],
+                  );
+                },
               );
             },
           ),
@@ -164,7 +191,7 @@ class _TasksPageState extends State<TasksPage> {
     );
   }
 
-  Widget _buildView(List<CustomTask> tasks) {
+  Widget _buildView(List<CustomTask> tasks, List<TaskFolder> folders) {
     if (_viewMode == TaskViewMode.calendar) {
       return TasksCalendarView(
         refreshNotifier: _calendarRefreshNotifier,
@@ -173,6 +200,7 @@ class _TasksPageState extends State<TasksPage> {
     } else {
       return TasksListView(
         tasks: tasks,
+        folders: folders,
         onToggleStatus: _toggleStatus,
         onCollaboratorChanged: (t, uid) async {
           t.responsable = uid ?? '';
@@ -239,7 +267,7 @@ class _TasksPageState extends State<TasksPage> {
     }
   }
 
-  Widget _buildHorizontalMenu(List<CustomTask> tasks) {
+  Widget _buildHorizontalMenu(List<CustomTask> tasks, List<TaskFolder> folders) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
       child: Row(
@@ -270,6 +298,12 @@ class _TasksPageState extends State<TasksPage> {
                 child: Text('Calendrier'),
               ),
             ],
+          ),
+          const SizedBox(width: 24),
+          ElevatedButton.icon(
+            onPressed: _showCreateFolderDialog,
+            icon: const Icon(Icons.create_new_folder),
+            label: const Text('Nouveau dossier'),
           ),
           const SizedBox(width: 24),
           if (_viewMode == TaskViewMode.list) ...[
@@ -386,6 +420,23 @@ class _TasksPageState extends State<TasksPage> {
     }
   }
 
+  Stream<List<TaskFolder>> _getFoldersStream() {
+    final db = FirebaseFirestore.instance;
+    if (widget.projectId != null && widget.projectId!.isNotEmpty) {
+      return db
+          .collection('taskFolders')
+          .where('projectId', isEqualTo: widget.projectId)
+          .snapshots()
+          .map((snap) => snap.docs
+              .map((d) => TaskFolder.fromMap(d.data() as Map<String, dynamic>, d.id))
+              .toList());
+    } else {
+      return db.collection('taskFolders').snapshots().map((snap) => snap.docs
+          .map((d) => TaskFolder.fromMap(d.data() as Map<String, dynamic>, d.id))
+          .toList());
+    }
+  }
+
   bool _sameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
@@ -398,6 +449,7 @@ class _TasksPageState extends State<TasksPage> {
     // Construire les données à enregistrer
     final data = task.toMap(user.uid)
       ..['project'] = task.project
+      ..['folderId'] = task.folderId
       ..['updatedBy'] = user.uid
       ..['updatedAt'] = FieldValue.serverTimestamp();
 
@@ -423,5 +475,41 @@ class _TasksPageState extends State<TasksPage> {
     final db = FirebaseFirestore.instance;
     await db.collection('tasks').doc(task.id).delete();
     _calendarRefreshNotifier.value++;
+  }
+
+  Future<void> _showCreateFolderDialog() async {
+    final nameController = TextEditingController();
+    await showDialog(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: const Text('Nouveau dossier'),
+          content: TextField(
+            controller: nameController,
+            decoration: const InputDecoration(labelText: 'Nom'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Annuler'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final name = nameController.text.trim();
+                if (name.isNotEmpty) {
+                  final folder = TaskFolder(
+                    name: name,
+                    projectId: widget.projectId ?? '',
+                  );
+                  await TaskFolderService().createFolder(folder);
+                }
+                Navigator.of(ctx).pop();
+              },
+              child: const Text('Créer'),
+            )
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -7,9 +7,11 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../../main.dart'; // Pour accéder à AppColors
 
 import '../../tasks/models/custom_task_model.dart';
+import '../../tasks/models/task_folder_model.dart';
 
 class TasksListView extends StatelessWidget {
   final List<CustomTask> tasks;
+  final List<TaskFolder> folders;
   final Function(CustomTask) onToggleStatus;
   final Function(CustomTask, String?) onCollaboratorChanged;
   final Function(CustomTask, String?) onProjectChanged;
@@ -27,6 +29,7 @@ class TasksListView extends StatelessWidget {
   const TasksListView({
     Key? key,
     required this.tasks,
+    required this.folders,
     required this.onToggleStatus,
     required this.onCollaboratorChanged,
     required this.onProjectChanged,
@@ -71,9 +74,9 @@ class TasksListView extends StatelessWidget {
       );
     }
 
-    // Séparer les tâches "En cours" et "Terminées" selon le statut 'completed'
-    final enCours = tasks.where((t) => t.status != 'completed').toList();
-    final terminees = tasks.where((t) => t.status == 'completed').toList();
+    final rootTasks = tasks.where((t) => t.folderId == null || t.folderId!.isEmpty).toList();
+    final enCours = rootTasks.where((t) => t.status != 'completed').toList();
+    final terminees = rootTasks.where((t) => t.status == 'completed').toList();
 
     // On enveloppe le Column principal dans un GestureDetector transparent :
     return GestureDetector(
@@ -157,7 +160,7 @@ class TasksListView extends StatelessWidget {
                       ),
                     ),
                   ),
-                  ...terminees.map((task) => Column(
+                ...terminees.map((task) => Column(
                     children: [
                       _TaskRow(
                         key: ValueKey(task.id),
@@ -184,6 +187,47 @@ class TasksListView extends StatelessWidget {
                     ],
                   )),
                 ],
+                // Sections dossiers
+                ...folders.map((folder) {
+                  final list = tasks.where((t) => t.folderId == folder.id).toList();
+                  if (list.isEmpty) return const SizedBox.shrink();
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                        child: Text(
+                          folder.name,
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Theme.of(context).colorScheme.onBackground.withOpacity(0.7),
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                      ),
+                      ...list.map((task) => Column(
+                            children: [
+                              _TaskRow(
+                                key: ValueKey(task.id),
+                                task: task,
+                                onToggle: onToggleStatus,
+                                onCollaboratorChanged: onCollaboratorChanged,
+                                onProjectChanged: onProjectChanged,
+                                onDeadlineChanged: onDeadlineChanged,
+                                onOpenDetail: onOpenDetail,
+                                onDelete: onDeleteTask,
+                                multiSelectMode: multiSelectMode,
+                                isSelected: selectedTaskIds.contains(task.id),
+                                onTaskSelectToggle: onTaskSelectToggle,
+                              ),
+                              Divider(
+                                height: 1,
+                                color: Theme.of(context).colorScheme.onBackground.withOpacity(0.3),
+                              ),
+                            ],
+                          )),
+                    ],
+                  );
+                }).whereType<Widget>().toList(),
                 // Bouton pour ajouter une nouvelle tâche
                 Padding(
                   padding:


### PR DESCRIPTION
## Summary
- add `TaskFolder` model and CRUD service
- extend `CustomTask` with `folderId`
- group tasks by folder in list view and provide folder creation dialog
- save folder information when saving tasks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5fc810e88329b6a6b0ec197c0bee