### PR TITLE
Add version display and OTA update check

### DIFF
--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -3,7 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
+import '../../utils/update_util.dart';
 import '../../features/auth/views/login_screen.dart';
 import '../../main.dart'; // Pour AppTheme et themeNotifier
 import 'profile_screen.dart'; // Import de la page Profil
@@ -19,12 +21,21 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   late AppTheme _selectedTheme;
+  String _appVersion = '';
 
   @override
   void initState() {
     super.initState();
     // Récupère l’état actuel du themeNotifier
     _selectedTheme = themeNotifier.value;
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    setState(() {
+      _appVersion = info.version;
+    });
   }
 
   /// Sauvegarde et applique le thème sélectionné
@@ -175,12 +186,20 @@ class _SettingsPageState extends State<SettingsPage> {
             iconColor: tileIconColor,
             textColor: tileTextColor,
             trailing: Text(
-              '0.1.0',
+              _appVersion,
               style: TextStyle(
                 color: isDarkStyle ? Colors.white54 : Colors.black54,
               ),
             ),
             onTap: () {},
+          ),
+          _SettingTile(
+            icon: Icons.system_update_alt,
+            label: 'Mise à jour',
+            tileBgColor: tileBgColor,
+            iconColor: tileIconColor,
+            textColor: tileTextColor,
+            onTap: () => checkForUpdate(context),
           ),
           _SettingTile(
             icon: Icons.support_agent,

--- a/lib/utils/update_util.dart
+++ b/lib/utils/update_util.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:ota_update/ota_update.dart';
+
+Future<void> checkForUpdate(BuildContext context) async {
+  try {
+    final PackageInfo info = await PackageInfo.fromPlatform();
+    final response = await http.get(Uri.parse('https://example.com/version.json'));
+    if (response.statusCode != 200) {
+      _showError(context, 'Impossible de vérifier les mises à jour.');
+      return;
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final String remoteVersion = data['version'] as String? ?? '';
+    final String url = data['url'] as String? ?? '';
+
+    if (_isNewer(remoteVersion, info.version)) {
+      try {
+        await OtaUpdate().execute(url);
+      } catch (_) {
+        _showError(context, 'Échec du téléchargement ou permission refusée.');
+      }
+    }
+  } catch (_) {
+    _showError(context, 'Erreur lors de la vérification des mises à jour.');
+  }
+}
+
+bool _isNewer(String remote, String local) {
+  final r = remote.split('.').map(int.parse).toList();
+  final l = local.split('.').map(int.parse).toList();
+  for (var i = 0; i < r.length && i < l.length; i++) {
+    if (r[i] > l[i]) return true;
+    if (r[i] < l[i]) return false;
+  }
+  return r.length > l.length;
+}
+
+void _showError(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(message)),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,9 @@ dependencies:
   csv: ^6.0.0
   share_plus: ^11.0.0
   path_provider: ^2.1.5
+  package_info_plus: ^5.0.1
+  ota_update: ^4.0.0
+  http: ^1.1.0
 
   # PDF generation & printing
   pdf: ^3.10.4

--- a/test/settings_screen_test.dart
+++ b/test/settings_screen_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:tokan/settings/views/settings_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel('dev.fluttercommunity.plus/package_info');
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return {
+        'appName': 'tokan',
+        'packageName': 'com.example.tokan',
+        'version': '1.2.3',
+        'buildNumber': '1',
+        'buildSignature': '',
+        'installerStore': '',
+      };
+    });
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  testWidgets('affiche la version et le bouton de mise à jour', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.2.3'), findsOneWidget);
+    expect(find.text('Mise à jour'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `package_info_plus`, `ota_update` and `http` dependencies
- show app version in settings using `PackageInfo`
- add "Mise à jour" entry that triggers `checkForUpdate`
- implement update utility with download and error handling
- test that the version text and update button appear

## Testing
- `flutter pub get` *(fails: `command not found`)*
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c7c064a1c8329acc31d569270d690