### PR TITLE
Add folder button to task list header

### DIFF
--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -270,7 +270,16 @@ class TasksListView extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const SizedBox(width: 40), // Pour la colonne statut (cercle)
+          SizedBox(
+            width: 40,
+            child: IconButton(
+              icon: const Icon(Icons.folder, size: 20),
+              tooltip: 'Dossiers',
+              onPressed: () {},
+              padding: EdgeInsets.zero,
+              splashRadius: 20,
+            ),
+          ), // Pour la colonne statut (cercle)
           _vDiv(context),
           Expanded(
             flex: 3,


### PR DESCRIPTION
## Summary
- show folder icon button in task list header

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7cd8c7ec8329869ddfbface6116d