### PR TITLE
Move create folder button to task list

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -242,6 +242,7 @@ class _TasksPageState extends State<TasksPage> {
           );
           showTaskPanel = true;
         }),
+        onCreateFolder: _showCreateFolderDialog,
         onDeleteTask: _deleteTask,
 
         multiSelectMode: _multiSelectMode,
@@ -300,12 +301,7 @@ class _TasksPageState extends State<TasksPage> {
             ],
           ),
           const SizedBox(width: 24),
-          ElevatedButton.icon(
-            onPressed: _showCreateFolderDialog,
-            icon: const Icon(Icons.create_new_folder),
-            label: const Text('Nouveau dossier'),
-          ),
-          const SizedBox(width: 24),
+          // Bouton "Nouveau dossier" déplacé dans la liste des tâches
           if (_viewMode == TaskViewMode.list) ...[
             DropdownButton<String>(
               hint: const Text('Filtrer par collaborateur'),

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -18,6 +18,7 @@ class TasksListView extends StatelessWidget {
   final Function(CustomTask, DateTime?) onDeadlineChanged;
   final Function(CustomTask) onOpenDetail;
   final VoidCallback onAddTask;
+  final Future<void> Function() onCreateFolder;
   final Function(CustomTask) onDeleteTask;
 
   // ← Paramètres pour la sélection multiple
@@ -36,6 +37,7 @@ class TasksListView extends StatelessWidget {
     required this.onDeadlineChanged,
     required this.onOpenDetail,
     required this.onAddTask,
+    required this.onCreateFolder,
     required this.onDeleteTask,
 
     // ← Nouveaux paramètres :
@@ -55,19 +57,39 @@ class TasksListView extends StatelessWidget {
           margin: const EdgeInsets.all(24),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 32),
-            child: TextButton.icon(
-              onPressed: onAddTask,
-              style: TextButton.styleFrom(
-                foregroundColor: AppColors.purple,
-              ),
-              icon: const Icon(Icons.add),
-              label: Text(
-                'Ajouter une tâche',
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Theme.of(context).colorScheme.onSurface,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextButton.icon(
+                  onPressed: onAddTask,
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColors.purple,
+                  ),
+                  icon: const Icon(Icons.add),
+                  label: Text(
+                    'Ajouter une tâche',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
                 ),
-              ),
+                const SizedBox(width: 16),
+                TextButton.icon(
+                  onPressed: () => onCreateFolder(),
+                  style: TextButton.styleFrom(
+                    foregroundColor: Theme.of(context).colorScheme.primary,
+                  ),
+                  icon: const Icon(Icons.create_new_folder),
+                  label: Text(
+                    'Nouveau dossier',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),
@@ -228,28 +250,51 @@ class TasksListView extends StatelessWidget {
                     ],
                   );
                 }).whereType<Widget>().toList(),
-                // Bouton pour ajouter une nouvelle tâche
+                // Boutons pour ajouter une tâche ou un dossier
                 Padding(
                   padding:
-                  const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                      const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
                   child: Align(
                     alignment: Alignment.centerLeft,
-                    child: TextButton.icon(
-                      icon: const Icon(Icons.add),
-                      label: Text(
-                        "Ajouter une tâche...",
-                        style: TextStyle(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onBackground
-                              .withOpacity(0.7),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        TextButton.icon(
+                          icon: const Icon(Icons.add),
+                          label: Text(
+                            "Ajouter une tâche...",
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onBackground
+                                  .withOpacity(0.7),
+                            ),
+                          ),
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
+                          ),
+                          onPressed: onAddTask,
                         ),
-                      ),
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 12, horizontal: 16),
-                      ),
-                      onPressed: onAddTask,
+                        const SizedBox(width: 16),
+                        TextButton.icon(
+                          icon: const Icon(Icons.create_new_folder),
+                          label: Text(
+                            "Nouveau dossier",
+                            style: TextStyle(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onBackground
+                                  .withOpacity(0.7),
+                            ),
+                          ),
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
+                          ),
+                          onPressed: () => onCreateFolder(),
+                        ),
+                      ],
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- relocate the "Nouveau dossier" button from the horizontal menu to the task list
- pass callback to create folder from `TasksPage`
- fix callback type so the folder creation dialog appears

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c890bff2883299f285eb1a26ad70a