### PR TITLE
Change plugin list to cards

### DIFF
--- a/lib/features/library/views/library_screen.dart
+++ b/lib/features/library/views/library_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tokan/core/providers/plugin_provider.dart';
 import 'package:tokan/core/contract/plugin_contract.dart';
+import '../widgets/plugin_card.dart';
 
 class LibraryPage extends StatefulWidget {
   const LibraryPage({Key? key}) : super(key: key);
@@ -35,20 +36,23 @@ class _LibraryPageState extends State<LibraryPage> {
           ),
         ),
         Expanded(
-          child: ListView.builder(
+          child: GridView.builder(
+            padding: const EdgeInsets.all(8),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              childAspectRatio: 4 / 5,
+            ),
             itemCount: filtered.length,
             itemBuilder: (_, i) {
               final p = filtered[i];
               final installed = pluginProv.isInstalled(p.id);
-              return ListTile(
-                leading: Icon(p.iconData), // utilise iconData ici
-                title: Text(p.displayName),
-                trailing: ElevatedButton(
-                  child: Text(installed ? 'Désinstaller' : 'Installer'),
-                  onPressed: () => installed
-                      ? pluginProv.uninstall(p.id)
-                      : pluginProv.install(p.id),
-                ),
+              return PluginCard(
+                plugin: p,
+                installed: installed,
+                onInstall: () => pluginProv.install(p.id),
+                onUninstall: () => pluginProv.uninstall(p.id),
               );
             },
           ),

--- a/lib/features/library/widgets/plugin_card.dart
+++ b/lib/features/library/widgets/plugin_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import '../../../core/contract/plugin_contract.dart';
+
+class PluginCard extends StatelessWidget {
+  final PluginContract plugin;
+  final bool installed;
+  final VoidCallback onInstall;
+  final VoidCallback onUninstall;
+
+  const PluginCard({
+    Key? key,
+    required this.plugin,
+    required this.installed,
+    required this.onInstall,
+    required this.onUninstall,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(plugin.iconData, size: 40),
+            const SizedBox(height: 8),
+            Text(
+              plugin.displayName,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: installed ? onUninstall : onInstall,
+              child: Text(installed ? 'Désinstaller' : 'Installer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- display library plugins as cards using a grid
- add `PluginCard` widget

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c91328c2c8329a8892c41bae0a0f6