### PR TITLE
Add folder actions in task list view

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -242,8 +242,31 @@ class _TasksPageState extends State<TasksPage> {
           );
           showTaskPanel = true;
         }),
+        onAddTaskToFolder: (folder) => setState(() {
+          activeTask = CustomTask(
+            id: '',
+            name: '',
+            description: '',
+            status: '',
+            responsable: '',
+            deadline: null,
+            startTime: null,
+            endTime: null,
+            duration: null,
+            client: null,
+            project: widget.projectId,
+            originalProjectId: null,
+            recurrenceType: null,
+            recurrenceDays: null,
+            recurrenceIncludePast: null,
+            folderId: folder.id,
+            subTasks: [],
+          );
+          showTaskPanel = true;
+        }),
         onCreateFolder: _showCreateFolderDialog,
         onDeleteTask: _deleteTask,
+        onDeleteFolder: _deleteFolder,
 
         multiSelectMode: _multiSelectMode,
         selectedTaskIds: _selectedTaskIds,
@@ -503,5 +526,9 @@ class _TasksPageState extends State<TasksPage> {
         );
       },
     );
+  }
+
+  Future<void> _deleteFolder(TaskFolder folder) async {
+    await TaskFolderService().deleteFolder(folder.id);
   }
 }

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -18,8 +18,10 @@ class TasksListView extends StatelessWidget {
   final Function(CustomTask, DateTime?) onDeadlineChanged;
   final Function(CustomTask) onOpenDetail;
   final VoidCallback onAddTask;
+  final Function(TaskFolder) onAddTaskToFolder;
   final VoidCallback onCreateFolder;
   final Function(CustomTask) onDeleteTask;
+  final Function(TaskFolder) onDeleteFolder;
 
   // ← Paramètres pour la sélection multiple
   final bool multiSelectMode;
@@ -37,8 +39,10 @@ class TasksListView extends StatelessWidget {
     required this.onDeadlineChanged,
     required this.onOpenDetail,
     required this.onAddTask,
+    required this.onAddTaskToFolder,
     required this.onCreateFolder,
     required this.onDeleteTask,
+    required this.onDeleteFolder,
 
     // ← Nouveaux paramètres :
     required this.multiSelectMode,
@@ -219,18 +223,10 @@ class TasksListView extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.symmetric(
                             horizontal: 16, vertical: 4),
-                        child: Text(
-                          folder.name,
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyMedium
-                              ?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onBackground
-                                .withOpacity(0.7),
-                            fontWeight: FontWeight.bold,
-                          ),
+                        child: _FolderHeader(
+                          folder: folder,
+                          onAddTask: () => onAddTaskToFolder(folder),
+                          onDelete: () => onDeleteFolder(folder),
                         ),
                       ),
                       if (list.isEmpty)
@@ -1041,6 +1037,66 @@ class _TaskRowState extends State<_TaskRow> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _FolderHeader extends StatefulWidget {
+  final TaskFolder folder;
+  final VoidCallback onAddTask;
+  final VoidCallback onDelete;
+
+  const _FolderHeader({
+    Key? key,
+    required this.folder,
+    required this.onAddTask,
+    required this.onDelete,
+  }) : super(key: key);
+
+  @override
+  State<_FolderHeader> createState() => _FolderHeaderState();
+}
+
+class _FolderHeaderState extends State<_FolderHeader> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              widget.folder.name,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onBackground
+                        .withOpacity(0.7),
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ),
+          if (_hover) ...[
+            IconButton(
+              icon: const Icon(Icons.add, size: 16),
+              tooltip: 'Ajouter une tâche',
+              onPressed: widget.onAddTask,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
+            IconButton(
+              icon: const Icon(Icons.close, size: 16),
+              tooltip: 'Supprimer ce dossier',
+              onPressed: widget.onDelete,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
+          ],
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- show icons to delete folders or add tasks when hovering folder headers
- wire up folder task creation and deletion

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850453251008329a95d043d14340b23