### PR TITLE
Fix task resize animation

### DIFF
--- a/lib/shared/widgets/resizable_task_cell_widget.dart
+++ b/lib/shared/widgets/resizable_task_cell_widget.dart
@@ -253,7 +253,9 @@ class _ResizableTaskCellState extends State<ResizableTaskCell> {
         _notifyParentEndDrag();
       },
       child: AnimatedContainer(
-        duration: const Duration(milliseconds: 150),
+        duration: (_dragSide != null || _isDraggingVertically)
+            ? Duration.zero
+            : const Duration(milliseconds: 150),
         curve: Curves.easeOut,
         width: widget.availableWidth,
         height: _height,


### PR DESCRIPTION
## Summary
- disable animation during interactive resizing so only the dragged side moves

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046240c448329ae005a6bc09cad4d