### PR TITLE
Align folder header actions

### DIFF
--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -1067,18 +1067,17 @@ class _FolderHeaderState extends State<_FolderHeader> {
       onEnter: (_) => setState(() => _hover = true),
       onExit: (_) => setState(() => _hover = false),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: Text(
-              widget.folder.name,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onBackground
-                        .withOpacity(0.7),
-                    fontWeight: FontWeight.bold,
-                  ),
-            ),
+          Text(
+            widget.folder.name,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onBackground
+                      .withOpacity(0.7),
+                  fontWeight: FontWeight.bold,
+                ),
           ),
           if (_hover) ...[
             IconButton(


### PR DESCRIPTION
## Summary
- avoid using Expanded in folder header so the row only spans its content
- place the add and delete icons right next to the section title

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850486e9e188329b277e09b0f90e802