### PR TITLE
Fix task list mode section titles

### DIFF
--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -131,7 +131,7 @@ class TasksListView extends StatelessWidget {
                     padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
                     child: Text(
-                      "En cours",
+                      "EN COURS",
                       style:
                       Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: Theme.of(context)
@@ -175,7 +175,7 @@ class TasksListView extends StatelessWidget {
                     padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
                     child: Text(
-                      "Terminées",
+                      "TERMINÉES",
                       style:
                       Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: Theme.of(context)


### PR DESCRIPTION
## Summary
- uppercase section labels in task list mode

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685048b61754832985289ca647538c5f