### PR TITLE
Fix runtime type for project plugin toggles

### DIFF
--- a/lib/features/projects/views/project_settings_screen.dart
+++ b/lib/features/projects/views/project_settings_screen.dart
@@ -73,9 +73,8 @@ class _ProjectSettingsScreenState extends State<ProjectSettingsScreen> {
           final bool crmInstalled = pluginProv.isInstalled('crm');
 
 
-          final List<Widget> pluginToggles = PluginRegistry()
-              .availablePlugins
-              .map((plugin) {
+          final List<Widget> pluginToggles = List<Widget>.from(
+            PluginRegistry().availablePlugins.map((plugin) {
                 final installed = pluginProv.isInstalled(plugin.id);
                 return SwitchListTile(
                   title: Text(
@@ -97,8 +96,8 @@ class _ProjectSettingsScreenState extends State<ProjectSettingsScreen> {
                           style: const TextStyle(color: Colors.grey),
                         ),
                 );
-              })
-              .toList();
+              }),
+          );
 
           pluginToggles.add(const Divider(color: Colors.white24));
 


### PR DESCRIPTION
## Summary
- construct plugin toggle list with `List<Widget>.from` to avoid runtime type errors

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504ac035308329a0d81c4f3872df04