### PR TITLE
Remove duplicate CRM plugin message

### DIFF
--- a/lib/features/projects/views/project_settings_screen.dart
+++ b/lib/features/projects/views/project_settings_screen.dart
@@ -101,30 +101,22 @@ class _ProjectSettingsScreenState extends State<ProjectSettingsScreen> {
 
           pluginToggles.add(const Divider(color: Colors.white24));
 
-          pluginToggles.add(
-            ListTile(
-              enabled: crmInstalled,
-              leading: Icon(Icons.business_center,
-                  color: crmInstalled ? Colors.white : Colors.grey),
-              title: const Text('CRM',
-                  style: TextStyle(color: Colors.white)),
-              subtitle: crmInstalled
-                  ? null
-                  : const Text(
-              'Le plugin CRM n\'est pas installé',
-              style: TextStyle(color: Colors.grey),
-            ),
-              onTap: crmInstalled
-                  ? () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => CrmPlugin().buildMainScreen(context),
-                  ),
-                );
-              }
-                  : null,
-            ),
-          );
+          if (crmInstalled) {
+            pluginToggles.add(
+              ListTile(
+                leading: const Icon(Icons.business_center, color: Colors.white),
+                title:
+                    const Text('CRM', style: TextStyle(color: Colors.white)),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => CrmPlugin().buildMainScreen(context),
+                    ),
+                  );
+                },
+              ),
+            );
+          }
 
           return ListView(children: pluginToggles);
         },


### PR DESCRIPTION
## Summary
- show CRM project setting item only when CRM plugin is installed

## Testing
- `dart format lib/features/projects/views/project_settings_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685052edcb1c8329b29b531a292ef2ce