### PR TITLE
Show sidebar on project settings

### DIFF
--- a/lib/features/projects/widgets/project_detail_panel_widget.dart
+++ b/lib/features/projects/widgets/project_detail_panel_widget.dart
@@ -10,6 +10,8 @@ import '../../tasks/views/tasks_screen.dart';
 import '../views/project_settings_screen.dart';
 import 'discussion_screen.dart';
 
+import '../../../shared/interface/interface.dart';
+
 import '../../../plugins/crm/services/crm_plugin.dart'; // CrmPlugin
 
 class ProjectDetailPanel extends StatefulWidget {
@@ -381,8 +383,12 @@ class _ProjectDetailPanelState extends State<ProjectDetailPanel> {
                             tooltip: 'Paramètres du projet',
                             onPressed: () => Navigator.of(context).push(
                               MaterialPageRoute(
-                                builder: (_) => ProjectSettingsScreen(
-                                    projectId: widget.project.id),
+                                builder: (_) => HomeScreen(
+                                  initialIndex: 5,
+                                  child: ProjectSettingsScreen(
+                                    projectId: widget.project.id,
+                                  ),
+                                ),
                               ),
                             ),
                           ),

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -24,13 +24,15 @@ import '../../main.dart'; // Pour AppTheme, themeNotifier et AppColors
 import '../../features/notifications/services/notification_service.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({Key? key}) : super(key: key);
+  final int initialIndex;
+  final Widget? child;
+  const HomeScreen({Key? key, this.initialIndex = 0, this.child}) : super(key: key);
   @override
   _HomeScreenState createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  int _selectedIndex = 0;
+  late int _selectedIndex;
   bool _sidebarExpanded = false;
   bool _showLabels = false;
   Timer? _labelTimer;
@@ -40,6 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    _selectedIndex = widget.initialIndex;
     _notifService.init();
   }
 
@@ -64,6 +67,16 @@ class _HomeScreenState extends State<HomeScreen> {
       _showLabels = false;
       _sidebarExpanded = false;
     });
+  }
+
+  void _navigateToIndex(int index) {
+    if (widget.child != null) {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => HomeScreen(initialIndex: index)),
+      );
+    } else {
+      setState(() => _selectedIndex = index);
+    }
   }
 
   @override
@@ -167,7 +180,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 showLabel: _showLabels,
                 isSelected: _selectedIndex == i,
                 selectedBg: selectedBg,
-                onTap: () => setState(() => _selectedIndex = i),
+                onTap: () => _navigateToIndex(i),
               ),
             const Spacer(),
             // Items fixes en bas
@@ -185,7 +198,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 showLabel: _showLabels,
                 isSelected: _selectedIndex == i,
                 selectedBg: selectedBg,
-                onTap: () => setState(() => _selectedIndex = i),
+                onTap: () => _navigateToIndex(i),
               ),
             const SizedBox(height: 24),
           ],
@@ -199,7 +212,7 @@ class _HomeScreenState extends State<HomeScreen> {
         children: [
           sidebar,
           VerticalDivider(width: 1, color: dividerColor),
-          Expanded(child: pages[_selectedIndex]),
+          Expanded(child: widget.child ?? pages[_selectedIndex]),
         ],
       ),
     );
@@ -232,7 +245,7 @@ class _HomeScreenState extends State<HomeScreen> {
         showLabel: _showLabels,
         isSelected: _selectedIndex == index,
         selectedBg: selectedBg,
-        onTap: () => setState(() => _selectedIndex = index),
+        onTap: () => _navigateToIndex(index),
       );
     }
 
@@ -258,7 +271,7 @@ class _HomeScreenState extends State<HomeScreen> {
           isSelected: _selectedIndex == index,
           selectedBg: selectedBg,
           badgeCount: count > 0 ? count : null,
-          onTap: () => setState(() => _selectedIndex = index),
+          onTap: () => _navigateToIndex(index),
         );
       },
     );
@@ -278,7 +291,7 @@ class _HomeScreenState extends State<HomeScreen> {
         showLabel: _showLabels,
         isSelected: _selectedIndex == index,
         selectedBg: selectedBg,
-        onTap: () => setState(() => _selectedIndex = index),
+        onTap: () => _navigateToIndex(index),
       );
     }
 
@@ -309,7 +322,7 @@ class _HomeScreenState extends State<HomeScreen> {
               isSelected: _selectedIndex == index,
               selectedBg: selectedBg,
               badgeCount: count > 0 ? count : null,
-              onTap: () => setState(() => _selectedIndex = index),
+              onTap: () => _navigateToIndex(index),
             );
           },
         );


### PR DESCRIPTION
## Summary
- allow `HomeScreen` to host custom child widgets
- navigate to project settings with sidebar visible

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685053270c448329a606870f60b9a8b1