### PR TITLE
Remove new folder button when task list empty

### DIFF
--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -78,21 +78,9 @@ class TasksListView extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(width: 16),
-                TextButton.icon(
-                  onPressed: onCreateFolder,
-                  style: TextButton.styleFrom(
-                    foregroundColor: Theme.of(context).colorScheme.primary,
-                  ),
-                  icon: const Icon(Icons.create_new_folder),
-                  label: Text(
-                    'Nouveau dossier',
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
-                  ),
-                ),
+                // Lorsque la liste est vide, seul le bouton pour ajouter une
+                // tâche doit être affiché. Le bouton de création de dossier a
+                // été retiré pour simplifier l'interface dans ce cas précis.
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- clean up empty task list widget to only show 'Ajouter une tâche'

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505465df78832980125a7be19c1ba1