### PR TITLE
Remove duplicate CRM plugin toggle

### DIFF
--- a/lib/features/projects/views/project_settings_screen.dart
+++ b/lib/features/projects/views/project_settings_screen.dart
@@ -74,7 +74,9 @@ class _ProjectSettingsScreenState extends State<ProjectSettingsScreen> {
 
 
           final List<Widget> pluginToggles = List<Widget>.from(
-            PluginRegistry().availablePlugins.map((plugin) {
+            PluginRegistry().availablePlugins
+                .where((plugin) => plugin.id != 'crm')
+                .map((plugin) {
                 final installed = pluginProv.isInstalled(plugin.id);
                 return SwitchListTile(
                   title: Text(


### PR DESCRIPTION
## Summary
- avoid adding duplicate toggle for CRM plugin on the project settings screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850541f9fbc832994bd4105a6be7798