### PR TITLE
Center task detail panel

### DIFF
--- a/lib/features/calendar/views/calendar_screen.dart
+++ b/lib/features/calendar/views/calendar_screen.dart
@@ -944,30 +944,31 @@ class _CalendarPageState extends State<CalendarPage> {
                   child: Container(color: Colors.black.withOpacity(0.5)),
                 ),
               ),
-              Positioned(
-                top: 0,
-                bottom: 0,
-                right: 0,
-                width: 400,
-                child: Container(
+              Center(
+                child: Material(
                   color: Theme.of(context).brightness == Brightness.dark
                       ? AppColors.darkBackground
                       : Colors.white,
-                  child: TaskDetailPanel(
-                    task: _activeTask!,
-                    onSave: (updatedTask) async {
-                      await _saveTaskFromCalendar(updatedTask);
-                    },
-                    onClose: () => setState(() {
-                      _showTaskPanel = false;
-                      _activeTask = null;
-                    }),
-                    onMarkAsDone: () {
-                      // Optionnel : marquer terminé
-                    },
-                    onCalendarRefresh: () {
-                      _subscribeToTasks();
-                    },
+                  borderRadius: BorderRadius.circular(12),
+                  child: SizedBox(
+                    width: 500,
+                    height: MediaQuery.of(context).size.height * 0.8,
+                    child: TaskDetailPanel(
+                      task: _activeTask!,
+                      onSave: (updatedTask) async {
+                        await _saveTaskFromCalendar(updatedTask);
+                      },
+                      onClose: () => setState(() {
+                        _showTaskPanel = false;
+                        _activeTask = null;
+                      }),
+                      onMarkAsDone: () {
+                        // Optionnel : marquer terminé
+                      },
+                      onCalendarRefresh: () {
+                        _subscribeToTasks();
+                      },
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/projects/views/project_tasks_screen.dart
+++ b/lib/features/projects/views/project_tasks_screen.dart
@@ -539,45 +539,55 @@ class _ProjectTasksPageState extends State<ProjectTasksPage> {
               title: Text(widget.project.name),
             ),
             Expanded(
-              child: showTaskPanel && activeTask != null
-                  ? Row(
+              child: Stack(
                 children: [
-                  Expanded(child: buildTasksContent()),
-                  Container(
-                    width: 400,
-                    color: isDark
-                        ? AppColors.darkBackground
-                        : Theme.of(context).colorScheme.surface,
-                    child: TaskDetailPanel(
-                      task: activeTask!,
-                      onSave: (updatedTask) async {
-                        await saveTaskToFirestore(updatedTask);
-                        setState(() {
-                          showTaskPanel = false;
-                        });
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                              content: Text(
-                                  "Tâche '${updatedTask.name}' sauvegardée")),
-                        );
-                      },
-                      onClose: () {
-                        setState(() {
-                          showTaskPanel = false;
-                        });
-                      },
-                      onMarkAsDone: () async {
-                        activeTask!.status = 'terminée';
-                        await saveTaskToFirestore(activeTask!);
-                        setState(() {
-                          showTaskPanel = false;
-                        });
-                      },
+                  buildTasksContent(),
+                  if (showTaskPanel && activeTask != null) ...[
+                    Positioned.fill(
+                      child: GestureDetector(
+                        onTap: () => setState(() => showTaskPanel = false),
+                        child: Container(color: Colors.black.withOpacity(0.5)),
+                      ),
                     ),
-                  ),
+                    Center(
+                      child: Material(
+                        color: isDark
+                            ? AppColors.darkBackground
+                            : Theme.of(context).colorScheme.surface,
+                        borderRadius: BorderRadius.circular(12),
+                        child: SizedBox(
+                          width: 500,
+                          height: MediaQuery.of(context).size.height * 0.8,
+                          child: TaskDetailPanel(
+                            task: activeTask!,
+                            onSave: (updatedTask) async {
+                              await saveTaskToFirestore(updatedTask);
+                              setState(() {
+                                showTaskPanel = false;
+                              });
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text("Tâche '${updatedTask.name}' sauvegardée")),
+                              );
+                            },
+                            onClose: () {
+                              setState(() {
+                                showTaskPanel = false;
+                              });
+                            },
+                            onMarkAsDone: () async {
+                              activeTask!.status = 'terminée';
+                              await saveTaskToFirestore(activeTask!);
+                              setState(() {
+                                showTaskPanel = false;
+                              });
+                            },
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ],
-              )
-                  : buildTasksContent(),
+              ),
             ),
           ],
         ),

--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -132,27 +132,28 @@ class _TasksPageState extends State<TasksPage> {
             ),
 
           if (showTaskPanel && activeTask != null)
-            Positioned(
-              right: 0,
-              top: 0,
-              bottom: 0,
-              child: Container(
-                width: MediaQuery.of(context).size.width / 3,
+            Center(
+              child: Material(
                 color: Theme.of(context).colorScheme.surface,
-                child: TaskDetailPanel(
-                  task: activeTask!,
-                  onSave: (updated) async {
-                    await _saveTask(updated);
-                    setState(() => showTaskPanel = false);
-                    _calendarRefreshNotifier.value++;
-                  },
-                  onClose: () => setState(() => showTaskPanel = false),
-                  onMarkAsDone: () {
-                    if (activeTask != null) _toggleStatus(activeTask!);
-                  },
-                  onCalendarRefresh: () {
-                    _calendarRefreshNotifier.value++;
-                  },
+                borderRadius: BorderRadius.circular(12),
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width * 0.6,
+                  height: MediaQuery.of(context).size.height * 0.8,
+                  child: TaskDetailPanel(
+                    task: activeTask!,
+                    onSave: (updated) async {
+                      await _saveTask(updated);
+                      setState(() => showTaskPanel = false);
+                      _calendarRefreshNotifier.value++;
+                    },
+                    onClose: () => setState(() => showTaskPanel = false),
+                    onMarkAsDone: () {
+                      if (activeTask != null) _toggleStatus(activeTask!);
+                    },
+                    onCalendarRefresh: () {
+                      _calendarRefreshNotifier.value++;
+                    },
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- show task detail panel in a centered dialog instead of a side panel

## Testing
- `flutter format lib/features/tasks/views/tasks_screen.dart lib/features/projects/views/project_tasks_screen.dart lib/features/calendar/views/calendar_screen.dart` *(fails: command not found)*
- `dart format lib/features/tasks/views/tasks_screen.dart lib/features/projects/views/project_tasks_screen.dart lib/features/calendar/views/calendar_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506526ca64832996e34257eb7c2996