### PR TITLE
Add mobile responsive home screen

### DIFF
--- a/lib/features/auth/views/auth_gate.dart
+++ b/lib/features/auth/views/auth_gate.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../shared/interface/interface.dart';
+import '../../../shared/interface/mobile_interface.dart';
+import '../../../shared/interface/adaptive_home_screen.dart';
 import '../../../plugins/crm/providers/contact_provider.dart';
 import '../../../plugins/crm/providers/opportunity_provider.dart';
 import '../../../plugins/crm/providers/quote_provider.dart';
@@ -37,7 +39,7 @@ class AuthGate extends StatelessWidget {
             ChangeNotifierProvider(create: (_) => QuoteProvider()),
             // … ajoutez d'autres providers liés à l'utilisateur ici …
           ],
-          child: const HomeScreen(),
+          child: const AdaptiveHomeScreen(),
         );
       },
     );

--- a/lib/features/auth/views/login_screen.dart
+++ b/lib/features/auth/views/login_screen.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart'
 import 'package:firebase_auth/firebase_auth.dart';
 import 'register_screen.dart';
 import '../../../shared/interface/interface.dart'; // Ajuste le chemin si besoin
+import '../../../shared/interface/mobile_interface.dart';
+import '../../../shared/interface/adaptive_home_screen.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -31,7 +33,7 @@ class _LoginPageState extends State<LoginPage> {
     if (user != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const HomeScreen()),
+          MaterialPageRoute(builder: (_) => const AdaptiveHomeScreen()),
         );
       });
     }
@@ -55,7 +57,7 @@ class _LoginPageState extends State<LoginPage> {
       );
       // FirebaseAuth conserve automatiquement la session
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const HomeScreen()),
+        MaterialPageRoute(builder: (_) => const AdaptiveHomeScreen()),
       );
     } on FirebaseAuthException catch (e, st) {
       debugPrint('🔥 FirebaseAuthException: code=${e.code} message=${e.message}');

--- a/lib/features/auth/views/register_screen.dart
+++ b/lib/features/auth/views/register_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 
 // 🔄 Redirection vers l’interface principale de Sequoia
 import '../../../shared/interface/interface.dart'; // ajuste le chemin si besoin
+import '../../../shared/interface/mobile_interface.dart';
+import '../../../shared/interface/adaptive_home_screen.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({Key? key}) : super(key: key);
@@ -31,12 +33,12 @@ class _RegisterPageState extends State<RegisterPage> {
   @override
   void initState() {
     super.initState();
-    // Si déjà authentifié, on va direct sur HomeScreen
+    // Si déjà authentifié, on va direct sur l'interface adaptée
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const HomeScreen()),
+          MaterialPageRoute(builder: (_) => const AdaptiveHomeScreen()),
         );
       });
     }
@@ -260,9 +262,9 @@ class _RegisterPageState extends State<RegisterPage> {
         });
       }
 
-      // 3️⃣ Redirection vers HomeScreen
+      // 3️⃣ Redirection vers l'interface adaptée
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const HomeScreen()),
+        MaterialPageRoute(builder: (_) => const AdaptiveHomeScreen()),
       );
     } on FirebaseAuthException catch (e) {
       setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,8 @@ import 'features/auth/views/login_screen.dart';
 import 'features/auth/views/register_screen.dart';
 import 'features/auth/views/auth_gate.dart';
 import 'shared/interface/interface.dart'; // Pour HomeScreen
+import 'shared/interface/mobile_interface.dart';
+import 'shared/interface/adaptive_home_screen.dart';
 import 'firebase_options.dart';
 
 /// 1) Enum à trois valeurs
@@ -236,7 +238,7 @@ class MyApp extends StatelessWidget {
           routes: {
             '/login':    (_) => const LoginPage(),
             '/register': (_) => const RegisterPage(),
-            '/home':     (_) => const HomeScreen(),
+            '/home':     (_) => const AdaptiveHomeScreen(),
             // Les routes CRM / FSM / ESP sont gérées dynamiquement via PluginProvider
           },
         );

--- a/lib/shared/interface/adaptive_home_screen.dart
+++ b/lib/shared/interface/adaptive_home_screen.dart
@@ -1,0 +1,19 @@
+// lib/shared/interface/adaptive_home_screen.dart
+
+import 'package:flutter/material.dart';
+
+import 'interface.dart';
+import 'mobile_interface.dart';
+
+class AdaptiveHomeScreen extends StatelessWidget {
+  const AdaptiveHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width < 600) {
+      return const MobileHomeScreen();
+    }
+    return const HomeScreen();
+  }
+}

--- a/lib/shared/interface/mobile_interface.dart
+++ b/lib/shared/interface/mobile_interface.dart
@@ -1,0 +1,228 @@
+// lib/shared/interface/mobile_interface.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../core/providers/plugin_provider.dart';
+import '../../features/dashboard/views/dashboard_screen.dart';
+import '../../features/tasks/views/tasks_screen.dart';
+import '../../features/calendar/views/calendar_screen.dart';
+import '../../features/collaborators/views/collaborators_screen.dart';
+import '../../features/chat/views/messages_screen.dart';
+import '../../features/notifications/views/notifications_screen.dart';
+import '../../features/library/views/library_screen.dart';
+import '../../features/projects/views/projects_screen.dart';
+import '../../settings/views/settings_screen.dart';
+import '../../features/notifications/services/notification_service.dart';
+
+class MobileHomeScreen extends StatefulWidget {
+  const MobileHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  _MobileHomeScreenState createState() => _MobileHomeScreenState();
+}
+
+class _MobileHomeScreenState extends State<MobileHomeScreen> {
+  int _selectedIndex = 0;
+  final ValueNotifier<int> _calendarRefreshNotifier = ValueNotifier<int>(0);
+  final NotificationService _notifService = NotificationService();
+
+  @override
+  void initState() {
+    super.initState();
+    _notifService.init();
+  }
+
+  @override
+  void dispose() {
+    _notifService.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pluginProv = context.watch<PluginProvider>();
+
+    final basePages = <Widget>[
+      const DashboardScreen(),
+      const TasksPage(),
+      CalendarPage(refreshNotifier: _calendarRefreshNotifier),
+      const CollaboratorsPage(),
+      const MessagesPage(),
+      const NotificationsPage(),
+      const LibraryPage(),
+      ProjectsScreen(),
+      const SettingsPage(),
+    ];
+
+    final plugins = pluginProv.installedPlugins;
+
+    final pages = <Widget>[
+      basePages[0],
+      basePages[1],
+      basePages[2],
+      basePages[3],
+      basePages[4],
+      basePages[7],
+      for (final p in plugins) p.buildMainScreen(context),
+      basePages[5],
+      basePages[6],
+      basePages[8],
+    ];
+
+    final icons = <IconData>[
+      Icons.home,
+      Icons.task_alt,
+      Icons.calendar_today,
+      Icons.group,
+      Icons.message,
+      Icons.work,
+      for (final p in plugins) p.iconData,
+      Icons.notifications,
+      Icons.library_books,
+      Icons.settings,
+    ];
+
+    final labels = <String>[
+      'Accueil',
+      'Tâches',
+      'Calendrier',
+      'Collaborateurs',
+      'Messages',
+      'Projets',
+      for (final p in plugins) p.displayName,
+      'Notifications',
+      'Library',
+      'Paramètres',
+    ];
+
+    return Scaffold(
+      body: pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: (i) => setState(() => _selectedIndex = i),
+        type: BottomNavigationBarType.fixed,
+        items: [
+          for (int i = 0; i < pages.length; i++)
+            BottomNavigationBarItem(
+              icon: _buildIcon(i, icons[i]),
+              label: labels[i],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIcon(int index, IconData icon) {
+    if (icon == Icons.message) {
+      return _buildMessagesIcon(icon);
+    }
+    if (icon == Icons.notifications) {
+      return _buildNotificationsIcon(icon);
+    }
+    return Icon(icon);
+  }
+
+  Widget _buildMessagesIcon(IconData icon) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return Icon(icon);
+
+    final convStream = FirebaseFirestore.instance
+        .collection('conversations')
+        .where('participants', arrayContains: uid)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: convStream,
+      builder: (ctx, snap) {
+        final docs = snap.data?.docs ?? [];
+        int count = 0;
+        for (final d in docs) {
+          final data = d.data() as Map<String, dynamic>;
+          final unread = List<String>.from(data['unreadBy'] ?? []);
+          if (unread.contains(uid)) count++;
+        }
+        if (count == 0) return Icon(icon);
+        return Stack(
+          children: [
+            Icon(icon),
+            Positioned(
+              right: 0,
+              top: 0,
+              child: Container(
+                padding: const EdgeInsets.all(2),
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
+                ),
+                constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+                child: Text(
+                  '$count',
+                  style: const TextStyle(color: Colors.white, fontSize: 10),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildNotificationsIcon(IconData icon) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return Icon(icon);
+
+    final pendingStream = FirebaseFirestore.instance
+        .collection('collaborations')
+        .where('to', isEqualTo: uid)
+        .where('status', isEqualTo: 'pending')
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: pendingStream,
+      builder: (ctx, pendSnap) {
+        final pending = pendSnap.data?.size ?? 0;
+        final notifStream = FirebaseFirestore.instance
+            .collection('notifications')
+            .where('recipientId', isEqualTo: uid)
+            .where('read', isEqualTo: false)
+            .snapshots();
+
+        return StreamBuilder<QuerySnapshot>(
+          stream: notifStream,
+          builder: (ctx2, notifSnap) {
+            final count = (notifSnap.data?.size ?? 0) + pending;
+            if (count == 0) return Icon(icon);
+            return Stack(
+              children: [
+                Icon(icon),
+                Positioned(
+                  right: 0,
+                  top: 0,
+                  child: Container(
+                    padding: const EdgeInsets.all(2),
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                    constraints:
+                        const BoxConstraints(minWidth: 16, minHeight: 16),
+                    child: Text(
+                      '$count',
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 10),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create a mobile version of the HomeScreen with bottom navigation
- add AdaptiveHomeScreen wrapper to switch layouts based on width
- update authentication flows and routes to use the adaptive screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506b4a08f88329ab2f86232016b799