### PR TITLE
Move icons to header on mobile

### DIFF
--- a/lib/features/notifications/views/notifications_screen.dart
+++ b/lib/features/notifications/views/notifications_screen.dart
@@ -53,10 +53,6 @@ class NotificationsPage extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: bgColor,
-      appBar: AppBar(
-        title: const Text('Notifications'),
-        // On laisse AppBar prendre la couleur par défaut du thème
-      ),
       body: StreamBuilder<QuerySnapshot>(
         stream: requestsStream,
         builder: (ctx, snapReq) {

--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -64,13 +64,6 @@ class _SettingsPageState extends State<SettingsPage> {
       backgroundColor: isDarkStyle
           ? Colors.grey[900]
           : Theme.of(context).scaffoldBackgroundColor,
-      appBar: AppBar(
-        backgroundColor: isDarkStyle ? Colors.grey[850] : Colors.white,
-        foregroundColor: isDarkStyle ? Colors.white : Colors.black,
-        title: const Text('Paramètres'),
-        centerTitle: true,
-        elevation: 0,
-      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/shared/interface/mobile_interface.dart
+++ b/lib/shared/interface/mobile_interface.dart
@@ -98,20 +98,55 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
       'Paramètres',
     ];
 
+    final notifIndex = 6 + plugins.length;
+    final libraryIndex = notifIndex + 1;
+    final settingsIndex = notifIndex + 2;
+
+    final bottomItemsCount = notifIndex;
+    final showBottomNav = _selectedIndex < bottomItemsCount;
+
     return Scaffold(
-      body: pages[_selectedIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _selectedIndex,
-        onTap: (i) => setState(() => _selectedIndex = i),
-        type: BottomNavigationBarType.fixed,
-        items: [
-          for (int i = 0; i < pages.length; i++)
-            BottomNavigationBarItem(
-              icon: _buildIcon(i, icons[i]),
-              label: labels[i],
+      body: Stack(
+        children: [
+          pages[_selectedIndex],
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topRight,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: _buildNotificationsIcon(Icons.notifications),
+                    onPressed: () => setState(() => _selectedIndex = notifIndex),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.library_books),
+                    onPressed: () => setState(() => _selectedIndex = libraryIndex),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.settings),
+                    onPressed: () => setState(() => _selectedIndex = settingsIndex),
+                  ),
+                ],
+              ),
             ),
+          ),
         ],
       ),
+      bottomNavigationBar: showBottomNav
+          ? BottomNavigationBar(
+              currentIndex: _selectedIndex,
+              onTap: (i) => setState(() => _selectedIndex = i),
+              type: BottomNavigationBarType.fixed,
+              items: [
+                for (int i = 0; i < bottomItemsCount; i++)
+                  BottomNavigationBarItem(
+                    icon: _buildIcon(i, icons[i]),
+                    label: labels[i],
+                  ),
+              ],
+            )
+          : null,
     );
   }
 


### PR DESCRIPTION
## Summary
- move notifications, library and settings icons from bottom nav to a header on mobile
- remove page AppBars since a global header is now shown

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850711e7f0c832983796788deb46d78