### PR TITLE
Fix collaborator queries for Firestore rules

### DIFF
--- a/lib/features/chat/views/messages_screen.dart
+++ b/lib/features/chat/views/messages_screen.dart
@@ -39,6 +39,12 @@ class _MessagesPageState extends State<MessagesPage> with TickerProviderStateMix
   Stream<List<Map<String, dynamic>>> _getAcceptedCollaborators(String meUid) {
     return FirebaseFirestore.instance
         .collection('collaborations')
+        .where(
+          Filter.or(
+            Filter('from', isEqualTo: meUid),
+            Filter('to', isEqualTo: meUid),
+          ),
+        )
         .where('status', isEqualTo: 'accepted')
         .snapshots()
         .asyncMap((snap) async {

--- a/lib/features/collaborators/views/collaborators_screen.dart
+++ b/lib/features/collaborators/views/collaborators_screen.dart
@@ -190,6 +190,12 @@ class _CollaboratorsPageState extends State<CollaboratorsPage> {
       String currentUid) {
     return FirebaseFirestore.instance
         .collection('collaborations')
+        .where(
+          Filter.or(
+            Filter('from', isEqualTo: currentUid),
+            Filter('to', isEqualTo: currentUid),
+          ),
+        )
         .where('status', isEqualTo: 'accepted')
         .snapshots()
         .asyncMap((snapshot) async {

--- a/lib/features/projects/widgets/project_detail_panel_widget.dart
+++ b/lib/features/projects/widgets/project_detail_panel_widget.dart
@@ -102,6 +102,12 @@ class _ProjectDetailPanelState extends State<ProjectDetailPanel> {
     if (user == null) return Stream.value([]);
     return FirebaseFirestore.instance
         .collection('collaborations')
+        .where(
+          Filter.or(
+            Filter('from', isEqualTo: user.uid),
+            Filter('to', isEqualTo: user.uid),
+          ),
+        )
         .where('status', isEqualTo: 'accepted')
         .snapshots()
         .asyncMap((snap) async {

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -684,6 +684,12 @@ class _TaskRowState extends State<_TaskRow> {
                 child: StreamBuilder<QuerySnapshot>(
                   stream: FirebaseFirestore.instance
                       .collection('collaborations')
+                      .where(
+                        Filter.or(
+                          Filter('from', isEqualTo: FirebaseAuth.instance.currentUser!.uid),
+                          Filter('to', isEqualTo: FirebaseAuth.instance.currentUser!.uid),
+                        ),
+                      )
                       .where('status', isEqualTo: 'accepted')
                       .snapshots(),
                   builder: (ctx2, snap) {

--- a/lib/shared/widgets/task_details_panel_widget.dart
+++ b/lib/shared/widgets/task_details_panel_widget.dart
@@ -144,6 +144,12 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
     if (user == null) return Stream.value([]);
     return FirebaseFirestore.instance
         .collection('collaborations')
+        .where(
+          Filter.or(
+            Filter('from', isEqualTo: user.uid),
+            Filter('to', isEqualTo: user.uid),
+          ),
+        )
         .where('status', isEqualTo: 'accepted')
         .snapshots()
         .asyncMap((snap) async {


### PR DESCRIPTION
## Summary
- ensure collaborator and message queries filter by user using `Filter.or`
- update friend lookup streams to use the filtered query

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685073daa51483299fb813d14458e17d