### PR TITLE
Fix bottom menu visibility on library page

### DIFF
--- a/lib/shared/interface/mobile_interface.dart
+++ b/lib/shared/interface/mobile_interface.dart
@@ -25,6 +25,7 @@ class MobileHomeScreen extends StatefulWidget {
 
 class _MobileHomeScreenState extends State<MobileHomeScreen> {
   int _selectedIndex = 0;
+  int _bottomIndex = 0;
   final NotificationService _notifService = NotificationService();
 
   @override
@@ -93,7 +94,8 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
     final settingsIndex = notifIndex + 2;
 
     final bottomItemsCount = notifIndex;
-    final showBottomNav = _selectedIndex < bottomItemsCount;
+    final showBottomNav =
+        _selectedIndex < bottomItemsCount || _selectedIndex == libraryIndex;
 
     return Scaffold(
       body: Column(
@@ -126,8 +128,11 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
       ),
       bottomNavigationBar: showBottomNav
           ? BottomNavigationBar(
-              currentIndex: _selectedIndex,
-              onTap: (i) => setState(() => _selectedIndex = i),
+              currentIndex: _bottomIndex,
+              onTap: (i) => setState(() {
+                    _selectedIndex = i;
+                    _bottomIndex = i;
+                  }),
               type: BottomNavigationBarType.fixed,
               items: [
                 for (int i = 0; i < bottomItemsCount; i++)


### PR DESCRIPTION
## Summary
- keep the bottom navigation bar visible when opening the Library page
- maintain the currently selected bottom navigation item while on the Library screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/shared/interface/mobile_interface.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508144af948329b35f1ac85c72ce18