### PR TITLE
Implement draggable task ordering

### DIFF
--- a/lib/features/tasks/models/custom_task_model.dart
+++ b/lib/features/tasks/models/custom_task_model.dart
@@ -31,6 +31,12 @@ class CustomTask extends Equatable {
   /// Inclure ou non les occurrences antérieures
   bool? recurrenceIncludePast;
 
+  /// Ordre d'affichage des tâches
+  int? order;
+
+  /// Date de création de la tâche
+  DateTime? createdAt;
+
   CustomTask({
     this.id = '',
     required this.name,
@@ -49,6 +55,8 @@ class CustomTask extends Equatable {
     this.recurrenceType,
     this.recurrenceDays,
     this.recurrenceIncludePast,
+    this.order,
+    this.createdAt,
   }) : subTasks = subTasks ?? [];
 
   /// Retourne la DateTime de début en combinant la deadline et le startTime.
@@ -84,6 +92,7 @@ class CustomTask extends Equatable {
       'recurrenceDays': recurrenceDays,
       'recurrenceIncludePast': recurrenceIncludePast ?? false,
       'subTasks': subTasks.map((t) => t._toSubMap()).toList(),
+      'order': order,
       'createdBy': userId,
       'createdAt': FieldValue.serverTimestamp(),
     };
@@ -108,6 +117,8 @@ class CustomTask extends Equatable {
       'recurrenceDays': recurrenceDays,
       'recurrenceIncludePast': recurrenceIncludePast ?? false,
       'subTasks': subTasks.map((t) => t._toSubMap()).toList(),
+      'order': order,
+      'createdAt': createdAt != null ? Timestamp.fromDate(createdAt!) : null,
     };
   }
 
@@ -179,12 +190,14 @@ class CustomTask extends Equatable {
       recurrenceType: map['recurrenceType'] as String?,
       recurrenceDays: _mapToRecurrenceDays(map['recurrenceDays']),
       recurrenceIncludePast: map['recurrenceIncludePast'] as bool?,
+      order: map['order'] as int?,
+      createdAt: _mapToDate(map['createdAt']),
       subTasks: map['subTasks'] != null
           ? List<CustomTask>.from(
-        (map['subTasks'] as List).map(
-              (subMap) => CustomTask._fromSubMap(subMap as Map<String, dynamic>),
-        ),
-      )
+              (map['subTasks'] as List).map(
+                (subMap) => CustomTask._fromSubMap(subMap as Map<String, dynamic>),
+              ),
+            )
           : [],
     );
   }
@@ -208,12 +221,14 @@ class CustomTask extends Equatable {
       recurrenceType: map['recurrenceType'] as String?,
       recurrenceDays: _mapToRecurrenceDays(map['recurrenceDays']),
       recurrenceIncludePast: map['recurrenceIncludePast'] as bool?,
+      order: map['order'] as int?,
+      createdAt: _mapToDate(map['createdAt']),
       subTasks: map['subTasks'] != null
           ? List<CustomTask>.from(
-        (map['subTasks'] as List).map(
-              (subMap) => CustomTask._fromSubMap(subMap as Map<String, dynamic>),
-        ),
-      )
+              (map['subTasks'] as List).map(
+                (subMap) => CustomTask._fromSubMap(subMap as Map<String, dynamic>),
+              ),
+            )
           : [],
     );
   }
@@ -236,6 +251,8 @@ class CustomTask extends Equatable {
     String? recurrenceType,
     List<int>? recurrenceDays,
     bool? recurrenceIncludePast,
+    int? order,
+    DateTime? createdAt,
   }) {
     return CustomTask(
       id: id ?? this.id,
@@ -255,6 +272,8 @@ class CustomTask extends Equatable {
       recurrenceType: recurrenceType ?? this.recurrenceType,
       recurrenceDays: recurrenceDays != null ? List<int>.from(recurrenceDays) : this.recurrenceDays,
       recurrenceIncludePast: recurrenceIncludePast ?? this.recurrenceIncludePast,
+      order: order ?? this.order,
+      createdAt: createdAt ?? this.createdAt,
     );
   }
 
@@ -279,5 +298,7 @@ class CustomTask extends Equatable {
     recurrenceType,
     recurrenceDays,
     recurrenceIncludePast,
+    order,
+    createdAt,
   ];
 }

--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -287,6 +287,10 @@ class _TasksPageState extends State<TasksPage> {
             _multiSelectMode = !_multiSelectMode;
           });
         },
+        onSwapOrder: (a, b) async {
+          await _swapTaskOrder(a, b);
+          setState(() {});
+        },
       );
     }
   }
@@ -428,9 +432,11 @@ class _TasksPageState extends State<TasksPage> {
         }
       }
 
-      list.sort((a, b) =>
-          (a.deadline ?? DateTime(1970))
-              .compareTo(b.deadline ?? DateTime(1970)));
+      list.sort((a, b) {
+        final aOrder = a.order ?? -(a.createdAt?.millisecondsSinceEpoch ?? 0);
+        final bOrder = b.order ?? -(b.createdAt?.millisecondsSinceEpoch ?? 0);
+        return bOrder.compareTo(aOrder);
+      });
       return list;
     });
   }
@@ -468,10 +474,23 @@ class _TasksPageState extends State<TasksPage> {
       ..['updatedBy'] = user.uid
       ..['updatedAt'] = FieldValue.serverTimestamp();
 
+    if (task.id.isNotEmpty) {
+      data.remove('createdAt');
+      data.remove('createdBy');
+    }
+
+    if (task.order == null) {
+      task.order = DateTime.now().millisecondsSinceEpoch;
+      data['order'] = task.order;
+    } else {
+      data['order'] = task.order;
+    }
+
     if (task.id.isEmpty) {
       if (task.status.isEmpty) task.status = 'à venir';
       final docRef = await tasksCollection.add(data);
       task.id = docRef.id;
+      task.createdAt = DateTime.now();
     } else {
       await tasksCollection.doc(task.id).update(data);
     }
@@ -490,6 +509,17 @@ class _TasksPageState extends State<TasksPage> {
     final db = FirebaseFirestore.instance;
     await db.collection('tasks').doc(task.id).delete();
     _calendarRefreshNotifier.value++;
+  }
+
+  Future<void> _swapTaskOrder(CustomTask first, CustomTask second) async {
+    final db = FirebaseFirestore.instance;
+    final batch = db.batch();
+    final temp = first.order;
+    first.order = second.order;
+    second.order = temp;
+    batch.update(db.collection('tasks').doc(first.id), {'order': first.order});
+    batch.update(db.collection('tasks').doc(second.id), {'order': second.order});
+    await batch.commit();
   }
 
   Future<void> _showCreateFolderDialog() async {

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -27,6 +27,7 @@ class TasksListView extends StatelessWidget {
   final Set<String> selectedTaskIds;
   final Function(CustomTask, bool) onTaskSelectToggle;
   final VoidCallback onToggleMultiSelectMode;
+  final Future<void> Function(CustomTask, CustomTask) onSwapOrder;
 
   const TasksListView({
     Key? key,
@@ -47,6 +48,7 @@ class TasksListView extends StatelessWidget {
     required this.selectedTaskIds,
     required this.onTaskSelectToggle,
     required this.onToggleMultiSelectMode,
+    required this.onSwapOrder,
   }) : super(key: key);
 
   @override
@@ -99,6 +101,11 @@ class TasksListView extends StatelessWidget {
     }
 
     final rootTasks = tasks.where((t) => t.folderId == null || t.folderId!.isEmpty).toList();
+    rootTasks.sort((a, b) {
+      final aOrder = a.order ?? -(a.createdAt?.millisecondsSinceEpoch ?? 0);
+      final bOrder = b.order ?? -(b.createdAt?.millisecondsSinceEpoch ?? 0);
+      return bOrder.compareTo(aOrder);
+    });
     final enCours = rootTasks.where((t) => t.status != 'completed').toList();
     final terminees = rootTasks.where((t) => t.status == 'completed').toList();
 
@@ -140,11 +147,11 @@ class TasksListView extends StatelessWidget {
                       ),
                     ),
                   ),
-                  ...enCours.map((task) => Column(
+                  ...enCours.asMap().entries.map((entry) => Column(
                     children: [
                       _TaskRow(
-                        key: ValueKey(task.id),
-                        task: task,
+                        key: ValueKey(entry.value.id),
+                        task: entry.value,
                         onToggle: onToggleStatus,
                         onCollaboratorChanged: onCollaboratorChanged,
                         onProjectChanged: onProjectChanged,
@@ -152,9 +159,16 @@ class TasksListView extends StatelessWidget {
                         onOpenDetail: onOpenDetail,
                         onDelete: onDeleteTask,
 
+                        onMoveUp: entry.key > 0
+                            ? () => onSwapOrder(entry.value, enCours[entry.key - 1])
+                            : null,
+                        onMoveDown: entry.key < enCours.length - 1
+                            ? () => onSwapOrder(entry.value, enCours[entry.key + 1])
+                            : null,
+
                         // ← Paramètres multi-sélection
                         multiSelectMode: multiSelectMode,
-                        isSelected: selectedTaskIds.contains(task.id),
+                        isSelected: selectedTaskIds.contains(entry.value.id),
                         onTaskSelectToggle: onTaskSelectToggle,
                       ),
                       Divider(
@@ -184,11 +198,11 @@ class TasksListView extends StatelessWidget {
                       ),
                     ),
                   ),
-                  ...terminees.map((task) => Column(
+                  ...terminees.asMap().entries.map((entry) => Column(
                     children: [
                       _TaskRow(
-                        key: ValueKey(task.id),
-                        task: task,
+                        key: ValueKey(entry.value.id),
+                        task: entry.value,
                         onToggle: onToggleStatus,
                         onCollaboratorChanged: onCollaboratorChanged,
                         onProjectChanged: onProjectChanged,
@@ -196,9 +210,16 @@ class TasksListView extends StatelessWidget {
                         onOpenDetail: onOpenDetail,
                         onDelete: onDeleteTask,
 
+                        onMoveUp: entry.key > 0
+                            ? () => onSwapOrder(entry.value, terminees[entry.key - 1])
+                            : null,
+                        onMoveDown: entry.key < terminees.length - 1
+                            ? () => onSwapOrder(entry.value, terminees[entry.key + 1])
+                            : null,
+
                         // ← Paramètres multi-sélection
                         multiSelectMode: multiSelectMode,
-                        isSelected: selectedTaskIds.contains(task.id),
+                        isSelected: selectedTaskIds.contains(entry.value.id),
                         onTaskSelectToggle: onTaskSelectToggle,
                       ),
                       Divider(
@@ -214,7 +235,12 @@ class TasksListView extends StatelessWidget {
                 // Sections dossiers
                 ...folders.map((folder) {
                   final list =
-                  tasks.where((t) => t.folderId == folder.id).toList();
+                      tasks.where((t) => t.folderId == folder.id).toList()
+                        ..sort((a, b) {
+                          final aOrder = a.order ?? -(a.createdAt?.millisecondsSinceEpoch ?? 0);
+                          final bOrder = b.order ?? -(b.createdAt?.millisecondsSinceEpoch ?? 0);
+                          return bOrder.compareTo(aOrder);
+                        });
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -260,11 +286,11 @@ class TasksListView extends StatelessWidget {
                           ),
                         )
                       else
-                        ...list.map((task) => Column(
+                        ...list.asMap().entries.map((entry) => Column(
                           children: [
                             _TaskRow(
-                              key: ValueKey(task.id),
-                              task: task,
+                              key: ValueKey(entry.value.id),
+                              task: entry.value,
                               onToggle: onToggleStatus,
                               onCollaboratorChanged: onCollaboratorChanged,
                               onProjectChanged: onProjectChanged,
@@ -273,7 +299,13 @@ class TasksListView extends StatelessWidget {
                               onDelete: onDeleteTask,
                               multiSelectMode: multiSelectMode,
                               isSelected:
-                              selectedTaskIds.contains(task.id),
+                              selectedTaskIds.contains(entry.value.id),
+                              onMoveUp: entry.key > 0
+                                  ? () => onSwapOrder(entry.value, list[entry.key - 1])
+                                  : null,
+                              onMoveDown: entry.key < list.length - 1
+                                  ? () => onSwapOrder(entry.value, list[entry.key + 1])
+                                  : null,
                               onTaskSelectToggle: onTaskSelectToggle,
                             ),
                             Divider(
@@ -528,6 +560,9 @@ class _TaskRow extends StatefulWidget {
   final Function(CustomTask) onOpenDetail;
   final Function(CustomTask) onDelete;
 
+  final VoidCallback? onMoveUp;
+  final VoidCallback? onMoveDown;
+
   // ← Nouveaux paramètres pour la sélection multiple
   final bool multiSelectMode;
   final bool isSelected;
@@ -542,6 +577,9 @@ class _TaskRow extends StatefulWidget {
     required this.onDeadlineChanged,
     required this.onOpenDetail,
     required this.onDelete,
+
+    this.onMoveUp,
+    this.onMoveDown,
 
     required this.multiSelectMode,
     required this.isSelected,
@@ -1131,27 +1169,43 @@ class _TaskRowState extends State<_TaskRow> {
             _vDiv(context),
             // 6) Zone de droite (checkbox ou bouton de suppression individuelle)
             SizedBox(
-              width: 40,
+              width: 80,
               child: widget.multiSelectMode
-              // Mode multi-sélection : afficher la checkbox
                   ? Checkbox(
-                value: widget.isSelected,
-                onChanged: (v) {
-                  widget.onTaskSelectToggle(widget.task, v!);
-                },
-              )
-                  : (_hoverRow
-              // Mode normal + survol : afficher la croix de suppression
-                  ? IconButton(
-                icon: const Icon(Icons.close, color: Colors.red),
-                tooltip: 'Supprimer cette tâche',
-                onPressed: () => widget.onDelete(widget.task),
-                padding: const EdgeInsets.all(8),
-                constraints:
-                const BoxConstraints(), // pour ne pas ajouter de padding supplémentaire
-              )
-              // Mode normal + pas de survol : espace vide
-                  : Container()),
+                      value: widget.isSelected,
+                      onChanged: (v) {
+                        widget.onTaskSelectToggle(widget.task, v!);
+                      },
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        if (_hoverRow && widget.onMoveUp != null)
+                          IconButton(
+                            icon: const Icon(Icons.arrow_upward, size: 16),
+                            tooltip: 'Monter',
+                            onPressed: widget.onMoveUp,
+                            padding: EdgeInsets.zero,
+                            constraints: const BoxConstraints(),
+                          ),
+                        if (_hoverRow && widget.onMoveDown != null)
+                          IconButton(
+                            icon: const Icon(Icons.arrow_downward, size: 16),
+                            tooltip: 'Descendre',
+                            onPressed: widget.onMoveDown,
+                            padding: EdgeInsets.zero,
+                            constraints: const BoxConstraints(),
+                          ),
+                        if (_hoverRow)
+                          IconButton(
+                            icon: const Icon(Icons.close, color: Colors.red),
+                            tooltip: 'Supprimer cette tâche',
+                            onPressed: () => widget.onDelete(widget.task),
+                            padding: const EdgeInsets.all(8),
+                            constraints: const BoxConstraints(),
+                          ),
+                      ],
+                    ),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- allow tasks to hold `order` and `createdAt` info
- sort task streams and views using this order
- let users change order from the list view with move buttons

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ac9aab54832993bb7718764ae9e4