### PR TITLE
Fix Windows initialization for notifications

### DIFF
--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -19,8 +19,12 @@ class NotificationService {
   Future<void> init() async {
     // Initialisation des notifications locales
     const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const windowsSettings = WindowsInitializationSettings();
     await _localNotif.initialize(
-      const InitializationSettings(android: androidSettings),
+      const InitializationSettings(
+        android: androidSettings,
+        windows: windowsSettings,
+      ),
     );
     _listenFriendRequests();
     _listenFriendAcceptances();


### PR DESCRIPTION
## Summary
- add Windows initialization settings when starting the notification service

## Testing
- `no tests run`

------
https://chatgpt.com/codex/tasks/task_e_6850d141494c8329b68800853a89f2d7