### PR TITLE
Improve project information layout

### DIFF
--- a/lib/features/projects/widgets/project_detail_panel_widget.dart
+++ b/lib/features/projects/widgets/project_detail_panel_widget.dart
@@ -461,9 +461,12 @@ class _ProjectDetailPanelState extends State<ProjectDetailPanel> {
       padding: const EdgeInsets.all(16),
       child: Form(
         key: _formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
             TextFormField(
               controller: _descCtrl,
               maxLines: 3,
@@ -488,7 +491,10 @@ class _ProjectDetailPanelState extends State<ProjectDetailPanel> {
               onChanged: (_) => _autoSave(),
             ),
             const SizedBox(height: 16),
-            Text('Couleur du libellé', style: TextStyle(color: onSurface)),
+            Text(
+              'Couleur du libellé',
+              style: TextStyle(color: _selectedColor),
+            ),
             const SizedBox(height: 8),
             GestureDetector(
               onTap: _pickColor,
@@ -503,6 +509,8 @@ class _ProjectDetailPanelState extends State<ProjectDetailPanel> {
           ],
         ),
       ),
-    );
+    ),
+  ),
+);
   }
 }


### PR DESCRIPTION
## Summary
- center form fields in the project information tab
- restrict width of inputs for better layout
- color the 'Couleur du libellé' label with the current selection

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850c7e235a8832983f14c61104cd1f7