### PR TITLE
Clarify new folder button callback

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -242,6 +242,7 @@ class _TasksPageState extends State<TasksPage> {
           );
           showTaskPanel = true;
         }),
+        // Callback for the "Nouveau dossier" button shown when tasks are listed
         onCreateFolder: _showCreateFolderDialog,
         onDeleteTask: _deleteTask,
 


### PR DESCRIPTION
## Summary
- document the callback for creating a folder when tasks are listed

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685229e5e3e48329854d17d39c31a263