### PR TITLE
Add dashboard widget toggles

### DIFF
--- a/lib/core/providers/plugin_provider.dart
+++ b/lib/core/providers/plugin_provider.dart
@@ -6,15 +6,20 @@ import 'package:tokan/core/contract/plugin_contract.dart';
 /// Gère la liste des plugins installés (persistés avec SharedPreferences).
 class PluginProvider extends ChangeNotifier {
   static const _key = 'installedPlugins';
+  static const _widgetKey = 'enabledDashboardWidgets';
 
   final PluginRegistry registry = PluginRegistry();
   final Set<String> _installed = {};
+  final Set<String> _enabledWidgets = {};
   bool _initialized = false;
 
   bool get isInitialized => _initialized;
   List<String> get installedIds => List.unmodifiable(_installed);
   List<PluginContract> get installedPlugins => registry.availablePlugins
       .where((p) => _installed.contains(p.id))
+      .toList();
+  List<PluginContract> get enabledWidgetPlugins => registry.availablePlugins
+      .where((p) => _installed.contains(p.id) && _enabledWidgets.contains(p.id))
       .toList();
 
   PluginProvider() {
@@ -27,24 +32,33 @@ class PluginProvider extends ChangeNotifier {
     _installed
       ..clear()
       ..addAll(saved);
+    final widgetsSaved = prefs.getStringList(_widgetKey) ?? [];
+    _enabledWidgets
+      ..clear()
+      ..addAll(widgetsSaved);
     _initialized = true;
     notifyListeners();
   }
 
   bool isInstalled(String id) => _installed.contains(id);
+  bool isWidgetEnabled(String id) => _enabledWidgets.contains(id);
 
   Future<void> install(String id) async {
     if (_installed.add(id)) {
+      _enabledWidgets.add(id);
       final prefs = await SharedPreferences.getInstance();
       await prefs.setStringList(_key, _installed.toList());
+      await prefs.setStringList(_widgetKey, _enabledWidgets.toList());
       notifyListeners();
     }
   }
 
   Future<void> uninstall(String id) async {
     if (_installed.remove(id)) {
+      _enabledWidgets.remove(id);
       final prefs = await SharedPreferences.getInstance();
       await prefs.setStringList(_key, _installed.toList());
+      await prefs.setStringList(_widgetKey, _enabledWidgets.toList());
       notifyListeners();
     }
   }
@@ -52,11 +66,25 @@ class PluginProvider extends ChangeNotifier {
   Future<void> toggle(String id) async {
     if (_installed.contains(id)) {
       _installed.remove(id);
+      _enabledWidgets.remove(id);
     } else {
       _installed.add(id);
+      _enabledWidgets.add(id);
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(_key, _installed.toList());
+    await prefs.setStringList(_widgetKey, _enabledWidgets.toList());
+    notifyListeners();
+  }
+
+  Future<void> toggleWidget(String id) async {
+    if (_enabledWidgets.contains(id)) {
+      _enabledWidgets.remove(id);
+    } else {
+      _enabledWidgets.add(id);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_widgetKey, _enabledWidgets.toList());
     notifyListeners();
   }
 }

--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tokan/core/providers/plugin_provider.dart';
 import 'package:tokan/core/contract/plugin_contract.dart';
+import '../widgets/project_progress_widget.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({Key? key}) : super(key: key);
@@ -9,7 +10,7 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final pluginProv = context.watch<PluginProvider>();
-    final installedPlugins = pluginProv.installedPlugins;
+    final installedPlugins = pluginProv.enabledWidgetPlugins;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -18,7 +19,7 @@ class DashboardScreen extends StatelessWidget {
         children: [
           Text('Tableau de bord principal', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
-          // … vos autres widgets dashboard …
+          const ProjectProgressWidget(),
 
           if (installedPlugins.isNotEmpty) ...[
             const Divider(height: 32),

--- a/lib/features/dashboard/widgets/project_progress_widget.dart
+++ b/lib/features/dashboard/widgets/project_progress_widget.dart
@@ -127,17 +127,25 @@ class _ProjectProgressWidgetState extends State<ProjectProgressWidget> {
               ),
             ),
           ),
-          Expanded(
-            child: _isLoading
-                ? const Center(child: CircularProgressIndicator())
-                : _projectsData.isEmpty
-                ? const Center(
-              child: Text(
-                'Aucun projet trouvé',
-                style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic),
+          if (_isLoading)
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else if (_projectsData.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Center(
+                child: Text(
+                  'Aucun projet trouvé',
+                  style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic),
+                ),
               ),
             )
-                : ListView.builder(
+          else
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
               padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
               itemCount: _projectsData.length,
               itemBuilder: (context, index) {
@@ -145,7 +153,6 @@ class _ProjectProgressWidgetState extends State<ProjectProgressWidget> {
                 return _buildProjectCard(pd, context, glassBg);
               },
             ),
-          ),
         ],
       ),
     );

--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../features/auth/views/login_screen.dart';
 import '../../main.dart'; // Pour AppTheme et themeNotifier
 import 'profile_screen.dart'; // Import de la page Profil
+import 'widget_settings_screen.dart';
 
 /// Page Paramètres de l’app
 /// Ajoute les thèmes Clair / Sombre / Sequoia et persiste le choix.
@@ -118,6 +119,22 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
               ],
             ),
+          ),
+
+          const SizedBox(height: 8),
+          _SettingTile(
+            icon: Icons.widgets,
+            label: 'Widgets du dashboard',
+            tileBgColor: tileBgColor,
+            iconColor: tileIconColor,
+            textColor: tileTextColor,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const WidgetSettingsScreen()),
+              );
+            },
           ),
 
           const SizedBox(height: 16),

--- a/lib/settings/views/widget_settings_screen.dart
+++ b/lib/settings/views/widget_settings_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/providers/plugin_provider.dart';
+import '../../main.dart';
+
+/// Screen allowing to enable or disable dashboard widgets for installed plugins.
+class WidgetSettingsScreen extends StatelessWidget {
+  const WidgetSettingsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final pluginProv = context.watch<PluginProvider>();
+    final plugins = pluginProv.installedPlugins;
+
+    return Scaffold(
+      backgroundColor: AppColors.darkBackground,
+      appBar: AppBar(
+        backgroundColor: AppColors.darkGreyBackground,
+        foregroundColor: Colors.white,
+        title: const Text('Widgets du dashboard'),
+      ),
+      body: ListView(
+        children: plugins
+            .map((plugin) => SwitchListTile(
+                  title: Text(plugin.displayName,
+                      style: const TextStyle(color: Colors.white)),
+                  secondary: Icon(plugin.iconData, color: Colors.white),
+                  activeColor: AppColors.green,
+                  value: pluginProv.isWidgetEnabled(plugin.id),
+                  onChanged: (_) => pluginProv.toggleWidget(plugin.id),
+                ))
+            .toList(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show project progress widget on dashboard
- allow plugin widgets to be toggled individually
- store dashboard widget state in preferences
- add screen to manage dashboard widgets in settings
- fix layout issue in project progress widget

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852296932c48329aa661ca6a056daac