### PR TITLE
Make task detail panel wider and center save button

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -137,7 +137,7 @@ class _TasksPageState extends State<TasksPage> {
               top: 0,
               bottom: 0,
               child: Container(
-                width: MediaQuery.of(context).size.width / 3,
+                width: MediaQuery.of(context).size.width / 2,
                 color: Theme.of(context).colorScheme.surface,
                 child: TaskDetailPanel(
                   task: activeTask!,

--- a/lib/shared/widgets/task_details_panel_widget.dart
+++ b/lib/shared/widgets/task_details_panel_widget.dart
@@ -840,7 +840,7 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
 
               // --- Bouton Sauvegarder ---
               Row(
-                mainAxisAlignment: MainAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   ElevatedButton(
                     onPressed: () async {


### PR DESCRIPTION
## Summary
- enlarge task detail panel width to half of the screen
- horizontally center the "Enregistrer" button under the separator

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522fc8e01883298a97e492ad332c6d