### PR TITLE
Improve sub task UX in detail panel

### DIFF
--- a/lib/features/tasks/widgets/sub_task_list_widget.dart
+++ b/lib/features/tasks/widgets/sub_task_list_widget.dart
@@ -62,17 +62,19 @@ class _SubTaskListWidgetState extends State<SubTaskListWidget> {
           itemCount: widget.subTasks.length,
           itemBuilder: (context, index) {
             final subTask = widget.subTasks[index];
-            return GestureDetector(
-              onTap: () => widget.onEdit(index),
-              child: Card(
-                color: Colors.grey[800],
-                margin: const EdgeInsets.symmetric(vertical: 4),
-                child: ListTile(
-                  leading: IconButton(
-                    icon: subTask.status == 'terminé'
-                        ? const Icon(Icons.check, color: Colors.white)
-                        : const Icon(Icons.circle_outlined, color: Colors.white70),
-                    onPressed: () => widget.onToggleStatus(index),
+            return MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => widget.onEdit(index),
+                child: Card(
+                  color: Colors.grey[800],
+                  margin: const EdgeInsets.symmetric(vertical: 4),
+                  child: ListTile(
+                    leading: IconButton(
+                      icon: subTask.status == 'terminé'
+                          ? const Icon(Icons.check, color: Colors.white)
+                          : const Icon(Icons.circle_outlined, color: Colors.white70),
+                      onPressed: () => widget.onToggleStatus(index),
                   ),
                   title: Text(
                     subTask.name,
@@ -84,6 +86,7 @@ class _SubTaskListWidgetState extends State<SubTaskListWidget> {
                   trailing: IconButton(
                     icon: const Icon(Icons.delete, color: Colors.red),
                     onPressed: () => widget.onDelete(index),
+                  ),
                   ),
                 ),
               ),

--- a/lib/shared/widgets/task_details_panel_widget.dart
+++ b/lib/shared/widgets/task_details_panel_widget.dart
@@ -403,6 +403,28 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
                 ],
               ),
 
+              if (taskStack.length > 1)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 2,
+                        height: 20,
+                        color: onBg.withOpacity(0.5),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          taskStack[taskStack.length - 2].name,
+                          style: TextStyle(color: onBg.withOpacity(0.7)),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
               // --- Champ nom de tâche ---
               TextField(
                 controller: nameController,


### PR DESCRIPTION
## Summary
- show a hand cursor when hovering sub tasks
- display parent task name with a vertical line when editing a sub task

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523944e9888329a926c48de4b5ff36