### PR TITLE
Update quote UI styling

### DIFF
--- a/lib/plugins/crm/screens/quote_detail_screen.dart
+++ b/lib/plugins/crm/screens/quote_detail_screen.dart
@@ -83,10 +83,11 @@ class _QuoteDetailScreenState extends State<QuoteDetailScreen> {
 
       body: SafeArea(
         child: Container(
-          // couche « glass »
-          color: AppColors.glassBackground,
+          color: Colors.white,
           padding: const EdgeInsets.all(16),
-          child: _loading
+          child: DefaultTextStyle.merge(
+            style: const TextStyle(color: Colors.black),
+            child: _loading
               ? const Center(child: CircularProgressIndicator())
               : _quote == null
               ? const Center(child: Text('Devis introuvable'))
@@ -160,6 +161,7 @@ class _QuoteDetailScreenState extends State<QuoteDetailScreen> {
               ],
             ],
           ),
+        ),
         ),
       ),
     );

--- a/lib/plugins/crm/screens/quote_form_screen.dart
+++ b/lib/plugins/crm/screens/quote_form_screen.dart
@@ -147,11 +147,13 @@ class _QuoteFormScreenState extends State<QuoteFormScreen> {
       ),
       body: SafeArea(
         child: Container(
-          color: AppColors.glassBackground,
+          color: Colors.white,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
-          child: Form(
-            key: _formKey,
-            child: ListView(
+          child: DefaultTextStyle.merge(
+            style: const TextStyle(color: Colors.black),
+            child: Form(
+              key: _formKey,
+              child: ListView(
               children: [
                 TextFormField(
                   initialValue: _reference,

--- a/lib/plugins/crm/screens/quote_list_screen.dart
+++ b/lib/plugins/crm/screens/quote_list_screen.dart
@@ -50,6 +50,7 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
     final screenWidth = MediaQuery.of(context).size.width;
 
     return Scaffold(
+      backgroundColor: AppColors.darkGreyBackground,
       appBar: AppBar(
         title: const Text('Devis'),
         centerTitle: false,               // titre aligné à gauche
@@ -58,34 +59,43 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
       ),
       body: Stack(
         children: [
-          // 1) La liste des devis
-          if (prov.isLoading)
-            const Center(child: CircularProgressIndicator())
-          else if (prov.quotes.isEmpty)
-            Center(
-              child: ElevatedButton.icon(
-                onPressed: () => _openPanel(quoteId: null),
-                icon: const Icon(Icons.add),
-                label: const Text('Ajouter votre premier devis'),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Container(
+              color: Colors.white,
+              child: DefaultTextStyle.merge(
+                style: const TextStyle(color: Colors.black),
+                child: prov.isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : prov.quotes.isEmpty
+                        ? Center(
+                            child: ElevatedButton.icon(
+                              onPressed: () => _openPanel(quoteId: null),
+                              icon: const Icon(Icons.add),
+                              label:
+                                  const Text('Ajouter votre premier devis'),
+                            ),
+                          )
+                        : ListView.builder(
+                            itemCount: prov.quotes.length,
+                            itemBuilder: (_, i) {
+                              final q = prov.quotes[i];
+                              return Card(
+                                margin: const EdgeInsets.symmetric(
+                                    vertical: 4, horizontal: 8),
+                                child: ListTile(
+                                  title: Text(q.reference),
+                                  subtitle:
+                                      Text('${q.total.toStringAsFixed(2)} €'),
+                                  trailing: Text(q.status),
+                                  onTap: () => _openPanel(quoteId: q.id),
+                                ),
+                              );
+                            },
+                          ),
               ),
-            )
-          else
-            ListView.builder(
-              itemCount: prov.quotes.length,
-              itemBuilder: (_, i) {
-                final q = prov.quotes[i];
-                return Card(
-                  margin:
-                  const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-                  child: ListTile(
-                    title: Text(q.reference),
-                    subtitle: Text('${q.total.toStringAsFixed(2)} €'),
-                    trailing: Text(q.status),
-                    onTap: () => _openPanel(quoteId: q.id),
-                  ),
-                );
-              },
             ),
+          ),
 
           // 2) Overlay pour fermer au clic en dehors
           if (_showPanel)
@@ -107,11 +117,14 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
             width: screenWidth * 0.25,
             child: Material(
               elevation: 16,
-              color: AppColors.glassBackground,
-              child: SafeArea(
-                child: _panelQuoteId == null
-                    ? QuoteFormScreen(onSaved: _closePanel)
-                    : QuoteDetailScreen(quoteId: _panelQuoteId!),
+              color: Colors.white,
+              child: DefaultTextStyle.merge(
+                style: const TextStyle(color: Colors.black),
+                child: SafeArea(
+                  child: _panelQuoteId == null
+                      ? QuoteFormScreen(onSaved: _closePanel)
+                      : QuoteDetailScreen(quoteId: _panelQuoteId!),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- use a dark grey background for quote list
- display quote pages in white with black text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523a0bdfc08329bb1936d4b6a96623