### PR TITLE
Implement vertical parent task bar

### DIFF
--- a/lib/shared/widgets/task_details_panel_widget.dart
+++ b/lib/shared/widgets/task_details_panel_widget.dart
@@ -380,11 +380,28 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
           setState(() => _showResponsableDropdown = false);
         }
       },
-      child: Container(
-        color: bgColor,
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Column(
+      child: Row(
+        children: [
+          if (taskStack.length > 1)
+            Container(
+              width: 20,
+              color: bgColor,
+              alignment: Alignment.center,
+              child: RotatedBox(
+                quarterTurns: 3,
+                child: Text(
+                  taskStack[taskStack.length - 2].name,
+                  style: TextStyle(color: onBg.withOpacity(0.7)),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+          Expanded(
+            child: Container(
+              color: bgColor,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // --- En‐tête : bouton retour (si sous‐tâche) et fermeture ---
@@ -934,6 +951,9 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
           ),
         ),
       ),
-    );
+    ),
+  ],
+),
+);
   }
 }


### PR DESCRIPTION
## Summary
- add a narrow vertical bar when viewing a sub-task
- display the parent task name vertically inside that bar
- fix missing parentheses in widget layout

## Testing
- `dart format lib/shared/widgets/task_details_panel_widget.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523b0470a483298d0c32d9f1eccb71