### PR TITLE
Style quote UI

### DIFF
--- a/lib/plugins/crm/screens/quote_detail_screen.dart
+++ b/lib/plugins/crm/screens/quote_detail_screen.dart
@@ -83,10 +83,16 @@ class _QuoteDetailScreenState extends State<QuoteDetailScreen> {
 
       body: SafeArea(
         child: Container(
-          // couche « glass »
-          color: AppColors.glassBackground,
-          padding: const EdgeInsets.all(16),
-          child: _loading
+          color: AppColors.darkGreyBackground,
+          alignment: Alignment.topCenter,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Container(
+            width: 794,
+            color: Colors.white,
+            padding: const EdgeInsets.all(16),
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(color: Colors.black),
+              child: _loading
               ? const Center(child: CircularProgressIndicator())
               : _quote == null
               ? const Center(child: Text('Devis introuvable'))
@@ -159,6 +165,7 @@ class _QuoteDetailScreenState extends State<QuoteDetailScreen> {
                     style: Theme.of(context).textTheme.bodyMedium),
               ],
             ],
+            ),
           ),
         ),
       ),

--- a/lib/plugins/crm/screens/quote_form_screen.dart
+++ b/lib/plugins/crm/screens/quote_form_screen.dart
@@ -147,11 +147,18 @@ class _QuoteFormScreenState extends State<QuoteFormScreen> {
       ),
       body: SafeArea(
         child: Container(
-          color: AppColors.glassBackground,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
-          child: Form(
-            key: _formKey,
-            child: ListView(
+          color: AppColors.darkGreyBackground,
+          alignment: Alignment.topCenter,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Container(
+            width: 794,
+            color: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(color: Colors.black),
+              child: Form(
+              key: _formKey,
+              child: ListView(
               children: [
                 TextFormField(
                   initialValue: _reference,
@@ -286,6 +293,7 @@ class _QuoteFormScreenState extends State<QuoteFormScreen> {
             ),
           ),
         ),
+      ),
       ),
       bottomNavigationBar: SafeArea(
         child: Padding(


### PR DESCRIPTION
## Summary
- revert list UI changes
- give quote detail and form screens a centered A4-style page with dark grey background

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523a0bdfc08329bb1936d4b6a96623