### PR TITLE
Fix project access query and Windows notifications

### DIFF
--- a/lib/features/dashboard/widgets/project_progress_widget.dart
+++ b/lib/features/dashboard/widgets/project_progress_widget.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../../../main.dart'; // Pour accéder à AppTheme, AppColors et themeNotifier
 import '../../projects/models/project_models.dart';
 import '../../projects/services/project_service.dart';
@@ -76,10 +77,13 @@ class _ProjectProgressWidgetState extends State<ProjectProgressWidget> {
 
   Future<_ProjectData?> _fetchTasksForProject(Project project) async {
     try {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid == null) return null;
+
       final snap = await _firestore
-          .collection('projects')
-          .doc(project.id)
           .collection('tasks')
+          .where('project', isEqualTo: project.id)
+          .where('createdBy', isEqualTo: uid)
           .get();
 
       final tasks = snap.docs

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -19,8 +19,17 @@ class NotificationService {
   Future<void> init() async {
     // Initialisation des notifications locales
     const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    // Paramètres Windows requis pour l'initialisation
+    const windowsSettings = WindowsInitializationSettings(
+      appName: 'Tokan',
+      appUserModelId: 'com.tokan.tokan',
+      guid: '{769040d3-7f85-475c-a9a7-c59e2e46f28b}',
+    );
     await _localNotif.initialize(
-      const InitializationSettings(android: androidSettings),
+      const InitializationSettings(
+        android: androidSettings,
+        windows: windowsSettings,
+      ),
     );
     _listenFriendRequests();
     _listenFriendAcceptances();

--- a/lib/features/projects/services/project_service.dart
+++ b/lib/features/projects/services/project_service.dart
@@ -40,17 +40,20 @@ class ProjectService {
   /// Flux des projets accessibles à l'utilisateur (propriétaire ou collaborateur).
   Stream<List<Project>> getProjectsStream() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
-    return _projectsRef.snapshots().map((snap) {
+    if (uid == null) return const Stream.empty();
+
+    final query = _projectsRef.where(
+      Filter.or(
+        Filter('ownerId', isEqualTo: uid),
+        Filter('collaborators', arrayContains: uid),
+      ),
+    );
+
+    return query.snapshots().map((snap) {
       return snap.docs
           .map((d) =>
-          Project.fromMap(d.data() as Map<String, dynamic>, d.id))
-          .where((proj) {
-        if (uid == null) return false;
-        final isOwner = proj.ownerId == uid;
-        final isCollaborator =
-        proj.collaborators.any((c) => c.uid == uid);
-        return isOwner || isCollaborator;
-      }).toList();
+              Project.fromMap(d.data() as Map<String, dynamic>, d.id))
+          .toList();
     });
   }
 

--- a/lib/shared/widgets/task_details_panel_widget.dart
+++ b/lib/shared/widgets/task_details_panel_widget.dart
@@ -423,39 +423,58 @@ class _TaskDetailPanelState extends State<TaskDetailPanel> {
               if (taskStack.length > 1)
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8.0),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 2,
-                        height: 20,
-                        color: onBg.withOpacity(0.5),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          taskStack[taskStack.length - 2].name,
-                          style: TextStyle(color: onBg.withOpacity(0.7)),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ],
+                  child: Text(
+                    taskStack[taskStack.length - 2].name,
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: onBg,
+                    ),
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
 
               // --- Champ nom de tâche ---
-              TextField(
-                controller: nameController,
-                style: TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                  color: onBg,
+              if (taskStack.length > 1)
+                Row(
+                  children: [
+                    Container(
+                      width: 2,
+                      height: 20,
+                      color: onBg.withOpacity(0.5),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextField(
+                        controller: nameController,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: onBg,
+                        ),
+                        decoration: InputDecoration(
+                          border: InputBorder.none,
+                          hintText: "Nouvelle tâche…",
+                          hintStyle: TextStyle(color: onBgFadedLight),
+                        ),
+                      ),
+                    ),
+                  ],
+                )
+              else
+                TextField(
+                  controller: nameController,
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: onBg,
+                  ),
+                  decoration: InputDecoration(
+                    border: InputBorder.none,
+                    hintText: "Nouvelle tâche…",
+                    hintStyle: TextStyle(color: onBgFadedLight),
+                  ),
                 ),
-                decoration: InputDecoration(
-                  border: InputBorder.none,
-                  hintText: "Nouvelle tâche…",
-                  hintStyle: TextStyle(color: onBgFadedLight),
-                ),
-              ),
+
               const SizedBox(height: 8),
 
               // --- Champ client (optionnel) ---


### PR DESCRIPTION
## Summary
- get projects stream using OR filter on ownerId and collaborators
- load project task progress from the root `tasks` collection
- style parent and subtask titles differently
- add Windows initialization for `flutter_local_notifications`
- set required Windows parameters

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523cdb90a88329ba34acd80030edcb