### PR TITLE
Fix Windows initialization for notifications

### DIFF
--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -19,7 +19,11 @@ class NotificationService {
   Future<void> init() async {
     // Initialisation des notifications locales
     const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const windowsSettings = WindowsInitializationSettings();
+    const windowsSettings = WindowsInitializationSettings(
+      appName: 'tokan',
+      appUserModelId: 'com.tokan.tokan',
+      guid: '{00000000-0000-0000-0000-000000000000}',
+    );
     await _localNotif.initialize(
       const InitializationSettings(
         android: androidSettings,


### PR DESCRIPTION
## Summary
- add required Windows initialization parameters for local notifications

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852475523788329bf877166eb4791d2