### PR TITLE
Add dashboard widget settings

### DIFF
--- a/lib/core/providers/dashboard_widget_provider.dart
+++ b/lib/core/providers/dashboard_widget_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Gère la liste des widgets de dashboard activés.
+class DashboardWidgetProvider extends ChangeNotifier {
+  static const _prefsKey = 'enabledDashboardWidgets';
+
+  final Set<String> _enabled = {};
+  bool _initialized = false;
+
+  bool get isInitialized => _initialized;
+
+  /// S'assure que les [ids] spécifiés existent dans la liste activée.
+  /// Si aucune préférence n'a encore été sauvegardée, on active tout par défaut.
+  Future<void> ensureDefaults(Iterable<String> ids) async {
+    if (!_initialized) return;
+    if (_enabled.isEmpty) {
+      _enabled.addAll(ids);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(_prefsKey, _enabled.toList());
+      notifyListeners();
+    }
+  }
+
+  DashboardWidgetProvider() {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getStringList(_prefsKey) ?? [];
+    _enabled
+      ..clear()
+      ..addAll(saved);
+    _initialized = true;
+    notifyListeners();
+  }
+
+  bool isEnabled(String id) => _enabled.contains(id);
+
+  Future<void> toggle(String id) async {
+    if (_enabled.contains(id)) {
+      _enabled.remove(id);
+    } else {
+      _enabled.add(id);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, _enabled.toList());
+    notifyListeners();
+  }
+}

--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tokan/core/providers/plugin_provider.dart';
+import 'package:tokan/core/providers/dashboard_widget_provider.dart';
 import 'package:tokan/core/contract/plugin_contract.dart';
+import 'dashboard_widgets_screen.dart';
+import '../widgets/project_progress_widget.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({Key? key}) : super(key: key);
@@ -9,23 +12,49 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final pluginProv = context.watch<PluginProvider>();
+    final dashboardProv = context.watch<DashboardWidgetProvider>();
     final installedPlugins = pluginProv.installedPlugins;
+
+    dashboardProv.ensureDefaults([
+      DashboardWidgetsScreen.projectWidgetId,
+      for (final p in installedPlugins) p.id,
+    ]);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Tableau de bord principal', style: theme.textTheme.titleLarge),
+          Row(
+            children: [
+              Expanded(
+                child: Text('Tableau de bord principal',
+                    style: theme.textTheme.titleLarge),
+              ),
+              IconButton(
+                icon: const Icon(Icons.settings),
+                tooltip: 'Configurer les widgets',
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                        builder: (_) => const DashboardWidgetsScreen()),
+                  );
+                },
+              ),
+            ],
+          ),
           const SizedBox(height: 16),
-          // … vos autres widgets dashboard …
+          if (dashboardProv
+              .isEnabled(DashboardWidgetsScreen.projectWidgetId))
+            const ProjectProgressWidget(),
 
           if (installedPlugins.isNotEmpty) ...[
             const Divider(height: 32),
             Text('Extensions installées', style: theme.textTheme.titleMedium),
             const SizedBox(height: 12),
             for (final p in installedPlugins)
-              if (p.buildDashboardWidget(context) != null)
+              if (p.buildDashboardWidget(context) != null &&
+                  dashboardProv.isEnabled(p.id))
                 p.buildDashboardWidget(context)!,
           ],
         ],

--- a/lib/features/dashboard/views/dashboard_widgets_screen.dart
+++ b/lib/features/dashboard/views/dashboard_widgets_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../core/providers/dashboard_widget_provider.dart';
+import '../../../core/providers/plugin_provider.dart';
+
+/// Écran listant tous les widgets disponibles pour le dashboard et
+/// permettant de les activer ou désactiver.
+class DashboardWidgetsScreen extends StatelessWidget {
+  const DashboardWidgetsScreen({Key? key}) : super(key: key);
+
+  static const String projectWidgetId = 'projectProgress';
+
+  @override
+  Widget build(BuildContext context) {
+    final dashboardProv = context.watch<DashboardWidgetProvider>();
+    final pluginProv = context.watch<PluginProvider>();
+
+    final items = <_DashboardItem>[
+      _DashboardItem(
+        id: projectWidgetId,
+        label: 'Suivi projets',
+      ),
+      for (final p in pluginProv.installedPlugins)
+        if (p.buildDashboardWidget(context) != null)
+          _DashboardItem(id: p.id, label: p.displayName),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Widgets du dashboard')),
+      body: ListView(
+        children: [
+          for (final item in items)
+            SwitchListTile(
+              title: Text(item.label),
+              value: dashboardProv.isEnabled(item.id),
+              onChanged: (_) => dashboardProv.toggle(item.id),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DashboardItem {
+  final String id;
+  final String label;
+  _DashboardItem({required this.id, required this.label});
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:provider/provider.dart';
 
 // Vos providers existants
 import 'core/providers/plugin_provider.dart';
+import 'core/providers/dashboard_widget_provider.dart';
 
 import 'features/auth/services/auth_service.dart';
 import 'features/auth/views/login_screen.dart';
@@ -199,6 +200,7 @@ Future<void> main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PluginProvider()),
+        ChangeNotifierProvider(create: (_) => DashboardWidgetProvider()),
         // Les providers dépendant de l'utilisateur seront instanciés
         // plus tard, une fois authentifié, pour éviter les erreurs.
       ],


### PR DESCRIPTION
## Summary
- allow enabling or disabling dashboard widgets
- provide a settings screen to manage widget visibility
- add access button on dashboard to open the settings
- register provider for widget configuration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685250485b088329ac8a6073eac2eade