### PR TITLE
Fix user null type error in register screen

### DIFF
--- a/lib/features/auth/views/register_screen.dart
+++ b/lib/features/auth/views/register_screen.dart
@@ -259,12 +259,16 @@ class _RegisterPageState extends State<RegisterPage> {
           'username':    _usernameCtrl.text.trim(),
           'createdAt':   FieldValue.serverTimestamp(),
         });
-      }
 
-      // 3️⃣ Démarrage du formulaire d'onboarding
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => OnboardingFlow(user: user)),
-      );
+        // 3️⃣ Démarrage du formulaire d'onboarding
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (_) => OnboardingFlow(user: user)),
+        );
+      } else {
+        setState(() {
+          _errorMessage = "Erreur inattendue : utilisateur introuvable";
+        });
+      }
     } on FirebaseAuthException catch (e) {
       setState(() {
         switch (e.code) {


### PR DESCRIPTION
## Summary
- check that the created user is non-null before starting the onboarding flow
- handle unexpected null user with an error message

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6852d0a272608329ae77d8c64809e118