### PR TITLE
Add explore/schedule page with web tab logic

### DIFF
--- a/lib/features/onboarding/onboarding_flow.dart
+++ b/lib/features/onboarding/onboarding_flow.dart
@@ -3,6 +3,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../shared/interface/interface.dart';
+import 'views/explore_schedule_page.dart';
+import '../../utils/tab_launcher.dart';
 
 class OnboardingFlow extends StatefulWidget {
   final User user;
@@ -75,6 +77,9 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
       'themeColor': _selectedColor,
     });
     if (mounted) {
+      // Ouvre la page d'options dans un nouvel onglet sur le Web
+      openTab('/#/explore-schedule');
+      // Redirige l'utilisateur vers l'écran d'accueil dans l'onglet actuel
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(builder: (_) => const HomeScreen()),
       );

--- a/lib/features/onboarding/views/explore_schedule_page.dart
+++ b/lib/features/onboarding/views/explore_schedule_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/interface/interface.dart';
+import '../../../utils/tab_launcher.dart';
+
+class ExploreSchedulePage extends StatelessWidget {
+  const ExploreSchedulePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Que souhaitez-vous faire ?')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Choisissez comment continuer :',
+                style: TextStyle(fontSize: 18),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (_) => const HomeScreen()),
+                  );
+                },
+                child: const Text('Continuer la découverte'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () {
+                  openTab('https://example.com/rendezvous');
+                },
+                child: const Text('Prendre rendez-vous'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'features/auth/views/login_screen.dart';
 import 'features/auth/views/register_screen.dart';
 import 'features/auth/views/auth_gate.dart';
 import 'shared/interface/interface.dart'; // Pour HomeScreen
+import 'features/onboarding/views/explore_schedule_page.dart';
 import 'firebase_options.dart';
 
 /// 1) Enum à trois valeurs
@@ -234,9 +235,10 @@ class MyApp extends StatelessWidget {
           theme: themeToApply,
           home: const AuthGate(),
           routes: {
-            '/login':    (_) => const LoginPage(),
-            '/register': (_) => const RegisterPage(),
-            '/home':     (_) => const HomeScreen(),
+            '/login':          (_) => const LoginPage(),
+            '/register':       (_) => const RegisterPage(),
+            '/home':           (_) => const HomeScreen(),
+            '/explore-schedule':(_) => const ExploreSchedulePage(),
             // Les routes CRM / FSM / ESP sont gérées dynamiquement via PluginProvider
           },
         );

--- a/lib/utils/tab_launcher.dart
+++ b/lib/utils/tab_launcher.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import 'tab_launcher_stub.dart'
+    if (dart.library.html) 'tab_launcher_web.dart';
+
+/// Opens [url] in a new browser tab when running on web.
+void openTab(String url) {
+  if (kIsWeb) {
+    openTabImpl(url);
+  }
+}

--- a/lib/utils/tab_launcher_stub.dart
+++ b/lib/utils/tab_launcher_stub.dart
@@ -1,0 +1,1 @@
+void openTabImpl(String url) {}

--- a/lib/utils/tab_launcher_web.dart
+++ b/lib/utils/tab_launcher_web.dart
@@ -1,0 +1,5 @@
+import 'dart:html' as html;
+
+void openTabImpl(String url) {
+  html.window.open(url, '_blank');
+}


### PR DESCRIPTION
## Summary
- add `ExploreSchedulePage` letting users continue or schedule a meeting
- launch a new browser tab after onboarding using `openTab`
- route `/explore-schedule` opens the new page
- implement cross-platform `openTab` helper

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d140ad7c83299826e1a2ff9f8f44