### PR TITLE
Update registration and profile layout

### DIFF
--- a/lib/features/auth/views/register_screen.dart
+++ b/lib/features/auth/views/register_screen.dart
@@ -15,14 +15,10 @@ class RegisterPage extends StatefulWidget {
 }
 
 class _RegisterPageState extends State<RegisterPage> {
-  final _displayNameCtrl = TextEditingController();
-  final _usernameCtrl    = TextEditingController();
-  final _emailCtrl       = TextEditingController();
-  final _passwordCtrl    = TextEditingController();
-  final _confirmCtrl     = TextEditingController();
+  final _emailCtrl    = TextEditingController();
+  final _passwordCtrl = TextEditingController();
 
   bool _showPassword = false;
-  bool _showConfirm  = false;
   final _formKey     = GlobalKey<FormState>();
   String? _errorMessage;
 
@@ -45,11 +41,8 @@ class _RegisterPageState extends State<RegisterPage> {
 
   @override
   void dispose() {
-    _displayNameCtrl.dispose();
-    _usernameCtrl.dispose();
     _emailCtrl.dispose();
     _passwordCtrl.dispose();
-    _confirmCtrl.dispose();
     super.dispose();
   }
 
@@ -77,28 +70,6 @@ class _RegisterPageState extends State<RegisterPage> {
                       ),
                     ),
                     const SizedBox(height: 32),
-
-                    // — Nom complet (displayName)
-                    _buildTextField(
-                      label: 'Nom complet',
-                      controller: _displayNameCtrl,
-                      obscure: false,
-                      validator: (v) => v == null || v.isEmpty
-                          ? "Veuillez entrer votre nom complet."
-                          : null,
-                    ),
-                    const SizedBox(height: 16),
-
-                    // — Nom d’utilisateur
-                    _buildTextField(
-                      label: 'Nom d’utilisateur',
-                      controller: _usernameCtrl,
-                      obscure: false,
-                      validator: (v) => v == null || v.isEmpty
-                          ? "Veuillez choisir un nom d’utilisateur."
-                          : null,
-                    ),
-                    const SizedBox(height: 16),
 
                     // — Email
                     _buildTextField(
@@ -129,28 +100,6 @@ class _RegisterPageState extends State<RegisterPage> {
                         if (v == null || v.isEmpty) return "Entrez un mot de passe.";
                         if (!passwordRegex.hasMatch(v)) {
                           return "Min. 6 caractères, 1 majuscule, 1 chiffre.";
-                        }
-                        return null;
-                      },
-                    ),
-                    const SizedBox(height: 16),
-
-                    // — Confirmation mot de passe
-                    _buildTextField(
-                      label: 'Confirmez le mot de passe',
-                      controller: _confirmCtrl,
-                      obscure: !_showConfirm,
-                      suffix: IconButton(
-                        icon: Icon(
-                          _showConfirm ? Icons.visibility : Icons.visibility_off,
-                          color: Colors.white70,
-                        ),
-                        onPressed: () => setState(() => _showConfirm = !_showConfirm),
-                      ),
-                      validator: (v) {
-                        if (v == null || v.isEmpty) return "Confirmez votre mot de passe.";
-                        if (v != _passwordCtrl.text) {
-                          return "Les mots de passe ne correspondent pas.";
                         }
                         return null;
                       },
@@ -254,10 +203,8 @@ class _RegisterPageState extends State<RegisterPage> {
             .collection('users')
             .doc(user.uid)
             .set({
-          'email':       user.email,
-          'displayName': _displayNameCtrl.text.trim(),
-          'username':    _usernameCtrl.text.trim(),
-          'createdAt':   FieldValue.serverTimestamp(),
+          'email':     user.email,
+          'createdAt': FieldValue.serverTimestamp(),
         });
 
         // 3️⃣ Démarrage du formulaire d'onboarding

--- a/lib/features/onboarding/onboarding_flow.dart
+++ b/lib/features/onboarding/onboarding_flow.dart
@@ -18,6 +18,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
   final _formKey = GlobalKey<FormState>();
   final _firstNameCtrl = TextEditingController();
   final _lastNameCtrl = TextEditingController();
+  final _usernameCtrl  = TextEditingController();
   final _phoneCtrl = TextEditingController();
   String _dialCode = '+33';
   final _companyCtrl = TextEditingController();
@@ -47,6 +48,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
   void dispose() {
     _firstNameCtrl.dispose();
     _lastNameCtrl.dispose();
+    _usernameCtrl.dispose();
     _phoneCtrl.dispose();
     _companyCtrl.dispose();
     _pageController.dispose();
@@ -72,6 +74,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
         .update({
       'firstName': _firstNameCtrl.text.trim(),
       'lastName': _lastNameCtrl.text.trim(),
+      'username':  _usernameCtrl.text.trim(),
       'phone': '$_dialCode ${_phoneCtrl.text.trim()}',
       'company': _selectedCompany ?? _companyCtrl.text.trim(),
       'themeColor': _selectedColor,
@@ -155,6 +158,12 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
               controller: _lastNameCtrl,
               decoration: const InputDecoration(labelText: 'Nom'),
               validator: (v) => v == null || v.isEmpty ? 'Entrez votre nom' : null,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _usernameCtrl,
+              decoration: const InputDecoration(labelText: 'Nom d\'utilisateur'),
+              validator: (v) => v == null || v.isEmpty ? 'Choisissez un pseudo' : null,
             ),
             const SizedBox(height: 12),
             Row(

--- a/lib/settings/views/profile_screen.dart
+++ b/lib/settings/views/profile_screen.dart
@@ -215,6 +215,34 @@ class _ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
+  Widget _buildTextField({
+    required String label,
+    required TextEditingController controller,
+    bool obscure = false,
+  }) {
+    return TextField(
+      controller: controller,
+      obscureText: obscure,
+      style: const TextStyle(color: Colors.white),
+      decoration: InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(color: Colors.white70),
+        filled: true,
+        fillColor: Colors.white10,
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        enabledBorder: OutlineInputBorder(
+          borderSide: const BorderSide(color: Colors.white38),
+          borderRadius: BorderRadius.circular(50),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderSide: const BorderSide(color: Colors.white),
+          borderRadius: BorderRadius.circular(50),
+        ),
+      ),
+    );
+  }
+
   @override
   void dispose() {
     _usernameController.dispose();
@@ -230,17 +258,22 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final isDark = theme.brightness == Brightness.dark;
 
     return Scaffold(
+      backgroundColor: Colors.black,
       appBar: AppBar(
+        backgroundColor: Colors.black,
         title: const Text('Mon Profil'),
         centerTitle: true,
       ),
       body: Stack(
         children: [
           SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 400),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
                 // ------------ Avatar ------------
                 Center(
                   child: Stack(
@@ -354,14 +387,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             // Mot de passe actuel
                             ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 350),
-                              child: TextField(
+                              child: _buildTextField(
+                                label: 'Mot de passe actuel',
                                 controller: _currentPwdController,
-                                obscureText: true,
-                                decoration: InputDecoration(
-                                  labelText: 'Mot de passe actuel',
-                                  border: const OutlineInputBorder(),
-                                  prefixIcon: const Icon(Icons.lock_outline),
-                                ),
+                                obscure: true,
                               ),
                             ),
                             const SizedBox(height: 12),
@@ -369,14 +398,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             // Nouveau mot de passe
                             ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 350),
-                              child: TextField(
+                              child: _buildTextField(
+                                label: 'Nouveau mot de passe',
                                 controller: _newPwdController,
-                                obscureText: true,
-                                decoration: InputDecoration(
-                                  labelText: 'Nouveau mot de passe',
-                                  border: const OutlineInputBorder(),
-                                  prefixIcon: const Icon(Icons.vpn_key),
-                                ),
+                                obscure: true,
                               ),
                             ),
                             const SizedBox(height: 12),
@@ -384,14 +409,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             // Confirmer le mot de passe
                             ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 350),
-                              child: TextField(
+                              child: _buildTextField(
+                                label: 'Confirmer le mot de passe',
                                 controller: _confirmPwdController,
-                                obscureText: true,
-                                decoration: InputDecoration(
-                                  labelText: 'Confirmer le mot de passe',
-                                  border: const OutlineInputBorder(),
-                                  prefixIcon: const Icon(Icons.vpn_key_outlined),
-                                ),
+                                obscure: true,
                               ),
                             ),
                             const SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- simplify `RegisterPage` to only request email & password
- ask for username during onboarding
- center content and apply login-style fields on profile page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d3f3db388329981bcff43e8d8970