### PR TITLE
Fix onboarding import path and loading indicator

### DIFF
--- a/lib/features/onboarding/onboarding_flow.dart
+++ b/lib/features/onboarding/onboarding_flow.dart
@@ -3,7 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../shared/interface/interface.dart';
-import 'views/explore_schedule_page.dart';
+import 'package:tokan/features/onboarding/views/explore_schedule_page.dart';
 import '../../utils/tab_launcher.dart';
 
 class OnboardingFlow extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'features/auth/views/login_screen.dart';
 import 'features/auth/views/register_screen.dart';
 import 'features/auth/views/auth_gate.dart';
 import 'shared/interface/interface.dart'; // Pour HomeScreen
-import 'features/onboarding/views/explore_schedule_page.dart';
+import 'package:tokan/features/onboarding/views/explore_schedule_page.dart';
 import 'firebase_options.dart';
 
 /// 1) Enum à trois valeurs

--- a/lib/settings/views/profile_screen.dart
+++ b/lib/settings/views/profile_screen.dart
@@ -443,11 +443,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
           ),
 
           // Indicateur de chargement semi-transparent
-          if (_isLoading)
-            Container(
+          Visibility(
+            visible: _isLoading,
+            child: Container(
               color: Colors.black45,
               child: const Center(child: CircularProgressIndicator()),
             ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- correct import path for explore schedule page
- update main import path
- use `Visibility` for loading indicator in profile screen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852d7798ed08329b76c1ce434a09d6a