### PR TITLE
Add DashboardWidgetProvider and connect to dashboard

### DIFF
--- a/lib/features/dashboard/providers/dashboard_widget_provider.dart
+++ b/lib/features/dashboard/providers/dashboard_widget_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+
+/// Manages dashboard widgets that can be injected by plugins or other features.
+class DashboardWidgetProvider extends ChangeNotifier {
+  final List<Widget> _widgets = [];
+
+  /// Widgets currently registered to display on the dashboard.
+  List<Widget> get widgets => List.unmodifiable(_widgets);
+
+  /// Registers a new widget and notifies listeners.
+  void addWidget(Widget widget) {
+    _widgets.add(widget);
+    notifyListeners();
+  }
+
+  /// Removes a widget and notifies listeners.
+  void removeWidget(Widget widget) {
+    _widgets.remove(widget);
+    notifyListeners();
+  }
+}

--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tokan/core/providers/plugin_provider.dart';
 import 'package:tokan/core/contract/plugin_contract.dart';
+import '../providers/dashboard_widget_provider.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({Key? key}) : super(key: key);
@@ -10,6 +11,7 @@ class DashboardScreen extends StatelessWidget {
     final theme = Theme.of(context);
     final pluginProv = context.watch<PluginProvider>();
     final installedPlugins = pluginProv.installedPlugins;
+    final dashboardProv = context.watch<DashboardWidgetProvider>();
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -28,6 +30,8 @@ class DashboardScreen extends StatelessWidget {
               if (p.buildDashboardWidget(context) != null)
                 p.buildDashboardWidget(context)!,
           ],
+
+          for (final w in dashboardProv.widgets) w,
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:provider/provider.dart';
 
 // Vos providers existants
 import 'core/providers/plugin_provider.dart';
+import 'features/dashboard/providers/dashboard_widget_provider.dart';
 
 import 'features/auth/services/auth_service.dart';
 import 'features/auth/views/login_screen.dart';
@@ -199,6 +200,7 @@ Future<void> main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PluginProvider()),
+        ChangeNotifierProvider(create: (_) => DashboardWidgetProvider()),
         // Les providers dépendant de l'utilisateur seront instanciés
         // plus tard, une fois authentifié, pour éviter les erreurs.
       ],


### PR DESCRIPTION
## Summary
- add new `DashboardWidgetProvider`
- register provider in `main.dart`
- use provider in `DashboardScreen`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e4aa24c8832998d989bd207b3a8f