### PR TITLE
Add dashboard widget management

### DIFF
--- a/lib/features/dashboard/providers/dashboard_widget_provider.dart
+++ b/lib/features/dashboard/providers/dashboard_widget_provider.dart
@@ -18,4 +18,15 @@ class DashboardWidgetProvider extends ChangeNotifier {
     _widgets.remove(widget);
     notifyListeners();
   }
+
+  /// Returns true if a widget of type [T] is currently registered.
+  bool hasWidgetOfType<T>() {
+    return _widgets.any((w) => w is T);
+  }
+
+  /// Removes all widgets of type [T] and notifies listeners.
+  void removeWidgetOfType<T>() {
+    _widgets.removeWhere((w) => w is T);
+    notifyListeners();
+  }
 }

--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:tokan/core/providers/plugin_provider.dart';
 import 'package:tokan/core/contract/plugin_contract.dart';
 import '../providers/dashboard_widget_provider.dart';
+import 'manage_dashboard_widgets_sheet.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({Key? key}) : super(key: key);
@@ -18,7 +19,22 @@ class DashboardScreen extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Tableau de bord principal', style: theme.textTheme.titleLarge),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Tableau de bord principal', style: theme.textTheme.titleLarge),
+              IconButton(
+                icon: const Icon(Icons.widgets),
+                tooltip: 'Gérer les widgets',
+                onPressed: () {
+                  showModalBottomSheet(
+                    context: context,
+                    builder: (_) => const ManageDashboardWidgetsSheet(),
+                  );
+                },
+              ),
+            ],
+          ),
           const SizedBox(height: 16),
           // … vos autres widgets dashboard …
 

--- a/lib/features/dashboard/views/manage_dashboard_widgets_sheet.dart
+++ b/lib/features/dashboard/views/manage_dashboard_widgets_sheet.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/dashboard_widget_provider.dart';
+import '../widgets/project_progress_widget.dart';
+
+/// Bottom sheet allowing the user to enable or disable dashboard widgets.
+class ManageDashboardWidgetsSheet extends StatefulWidget {
+  const ManageDashboardWidgetsSheet({Key? key}) : super(key: key);
+
+  @override
+  State<ManageDashboardWidgetsSheet> createState() => _ManageDashboardWidgetsSheetState();
+}
+
+class _ManageDashboardWidgetsSheetState extends State<ManageDashboardWidgetsSheet> {
+  bool _showProjectProgress = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final provider = context.read<DashboardWidgetProvider>();
+    _showProjectProgress = provider.hasWidgetOfType<ProjectProgressWidget>();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Widgets du dashboard',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          CheckboxListTile(
+            title: const Text('Progression des projets'),
+            value: _showProjectProgress,
+            onChanged: (val) {
+              setState(() => _showProjectProgress = val ?? false);
+              final provider = context.read<DashboardWidgetProvider>();
+              if (val == true) {
+                provider.addWidget(const ProjectProgressWidget());
+              } else {
+                provider.removeWidgetOfType<ProjectProgressWidget>();
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 // Vos providers existants
 import 'core/providers/plugin_provider.dart';
 import 'features/dashboard/providers/dashboard_widget_provider.dart';
+import 'features/dashboard/widgets/project_progress_widget.dart';
 
 import 'features/auth/services/auth_service.dart';
 import 'features/auth/views/login_screen.dart';
@@ -200,7 +201,10 @@ Future<void> main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => PluginProvider()),
-        ChangeNotifierProvider(create: (_) => DashboardWidgetProvider()),
+        ChangeNotifierProvider(
+          create: (_) => DashboardWidgetProvider()
+            ..addWidget(const ProjectProgressWidget()),
+        ),
         // Les providers dépendant de l'utilisateur seront instanciés
         // plus tard, une fois authentifié, pour éviter les erreurs.
       ],


### PR DESCRIPTION
## Summary
- show ProjectProgressWidget by default
- offer a new manage dashboard widgets sheet
- add management button in Dashboard screen
- extend DashboardWidgetProvider with helpers

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e767bd488329b5fb723f2464ece4