### PR TITLE
Implémentation du type de projet entreprise

### DIFF
--- a/lib/features/projects/models/project_models.dart
+++ b/lib/features/projects/models/project_models.dart
@@ -26,6 +26,9 @@ class Collaborator {
 }
 
 /// Modèle représentant un projet
+enum ProjectType { simple, entreprise }
+
+/// Modèle représentant un projet
 class Project {
   String id;
   String name;
@@ -35,7 +38,10 @@ class Project {
   List<Collaborator> collaborators;
   String? color; // code hexadécimal (ex: "ff00ff00")
 
-  /// ← NOUVEAU : liste des plugins installés pour ce projet
+  /// Type du projet : simple ou entreprise
+  ProjectType type;
+
+  /// Liste des plugins installés pour ce projet
   List<String>? plugins;
 
   Project({
@@ -46,6 +52,7 @@ class Project {
     this.objective,
     List<Collaborator>? collaborators,
     this.color,
+    this.type = ProjectType.simple,
     this.plugins, // ← prend en charge la liste des plugins (ex: ['crm', ...])
   }) : collaborators = collaborators ?? [];
 
@@ -58,6 +65,7 @@ class Project {
     String? objective,
     List<Collaborator>? collaborators,
     String? color,
+    ProjectType? type,
     List<String>? plugins, // ← on ajoute ce champ pour la copie
   }) {
     return Project(
@@ -68,6 +76,7 @@ class Project {
       objective: objective ?? this.objective,
       collaborators: collaborators ?? this.collaborators,
       color: color ?? this.color,
+      type: type ?? this.type,
       plugins: plugins ?? this.plugins,
     );
   }
@@ -78,6 +87,7 @@ class Project {
       'name': name,
       'description': description,
       'ownerId': ownerId,
+      'type': type == ProjectType.entreprise ? 'entreprise' : 'simple',
       if (objective != null) 'objective': objective,
       if (color != null) 'color': color,
       'collaborators': collaborators.map((c) => c.toMap()).toList(),
@@ -93,6 +103,9 @@ class Project {
       name: map['name'] as String? ?? '',
       description: map['description'] as String? ?? '',
       ownerId: map['ownerId'] as String? ?? '',
+      type: (map['type'] as String?) == 'entreprise'
+          ? ProjectType.entreprise
+          : ProjectType.simple,
       objective: map['objective'] as String?,
       color: map['color'] as String?,
       collaborators: (map['collaborators'] as List<dynamic>?)

--- a/lib/features/projects/views/projects_screen.dart
+++ b/lib/features/projects/views/projects_screen.dart
@@ -63,7 +63,7 @@ class ProjectsScreen extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(
                           horizontal: 16, vertical: 12),
                       child: Text(
-                        'Mes Projets',
+                        'Projets & Entreprises',
                         style: theme.textTheme.headlineLarge?.copyWith(
                           color: titleColor,
                           fontWeight: FontWeight.bold,
@@ -93,7 +93,7 @@ class ProjectsScreen extends StatelessWidget {
                         ),
                       ),
                       icon: const Icon(Icons.add),
-                      label: const Text('Créer un nouveau projet'),
+                      label: const Text('Créer un projet ou une entreprise'),
                       onPressed: () => _showCreateProjectDialog(context),
                     ),
                   ],
@@ -123,44 +123,69 @@ class ProjectsScreen extends StatelessWidget {
     );
   }
 
-  /// Dialogue pour saisir seulement le nom d’un nouveau projet
+  /// Dialogue pour créer un projet simple ou une entreprise
   Future<void> _showCreateProjectDialog(BuildContext context) async {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final nameCtrl = TextEditingController();
     final formKey = GlobalKey<FormState>();
+    ProjectType selectedType = ProjectType.simple;
 
     final created = await showDialog<bool>(
       context: context,
-      builder: (c) => AlertDialog(
-        backgroundColor:
-        isDark ? AppColors.darkGreyBackground : theme.colorScheme.surface,
-        title: Text(
-          'Nouveau projet',
-          style:
-          theme.textTheme.titleLarge?.copyWith(color: theme.colorScheme.onBackground),
-        ),
-        content: Form(
-          key: formKey,
-          child: TextFormField(
-            controller: nameCtrl,
-            decoration: InputDecoration(
-              labelText: 'Nom du projet',
-              hintText: 'Entrez un nom',
-              labelStyle: TextStyle(color: theme.colorScheme.onBackground),
-              enabledBorder: UnderlineInputBorder(
-                borderSide: BorderSide(
-                  color: theme.colorScheme.onBackground.withOpacity(0.3),
-                ),
-              ),
-            ),
-            style: TextStyle(color: theme.colorScheme.onBackground),
-            validator: (v) =>
-            v == null || v.trim().isEmpty ? 'Le nom est requis' : null,
-            autofocus: true,
+      builder: (c) => StatefulBuilder(
+        builder: (c, setSt) => AlertDialog(
+          backgroundColor:
+              isDark ? AppColors.darkGreyBackground : theme.colorScheme.surface,
+          title: Text(
+            'Nouveau projet',
+            style:
+                theme.textTheme.titleLarge?.copyWith(color: theme.colorScheme.onBackground),
           ),
-        ),
-        actions: [
+          content: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: nameCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Nom du projet',
+                    hintText: 'Entrez un nom',
+                    labelStyle: TextStyle(color: theme.colorScheme.onBackground),
+                    enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: theme.colorScheme.onBackground.withOpacity(0.3),
+                      ),
+                    ),
+                  ),
+                  style: TextStyle(color: theme.colorScheme.onBackground),
+                  validator: (v) => v == null || v.trim().isEmpty ? 'Le nom est requis' : null,
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<ProjectType>(
+                  value: selectedType,
+                  decoration: InputDecoration(
+                    labelText: 'Type de projet',
+                    labelStyle: TextStyle(color: theme.colorScheme.onBackground),
+                  ),
+                  items: const [
+                    DropdownMenuItem(
+                      value: ProjectType.simple,
+                      child: Text('Projet simple'),
+                    ),
+                    DropdownMenuItem(
+                      value: ProjectType.entreprise,
+                      child: Text("Projet d'entreprise"),
+                    ),
+                  ],
+                  onChanged: (val) => setSt(() => selectedType = val ?? ProjectType.simple),
+                ),
+              ],
+            ),
+          ),
+          actions: [
           TextButton(
             onPressed: () => Navigator.of(c).pop(false),
             child: Text(
@@ -180,6 +205,7 @@ class ProjectsScreen extends StatelessWidget {
                     ownerId: '', // sera géré par le service
                     collaborators: const [],
                     color: null,
+                    type: selectedType,
                   ),
                 );
                 Navigator.of(c).pop(true);
@@ -195,6 +221,7 @@ class ProjectsScreen extends StatelessWidget {
             ),
           ),
         ],
+        ),
       ),
     );
 

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -77,7 +77,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
     // 3) Concaténer pages dans l'ordre souhaité
     final pages = <Widget>[
-      // Haut : Accueil..Messages, puis Projets
+      // Haut : Accueil..Messages, puis Projets & Entreprises
       basePages[0],
       basePages[1],
       basePages[2],
@@ -99,7 +99,7 @@ class _HomeScreenState extends State<HomeScreen> {
       Icons.calendar_today,
       Icons.group,
       Icons.message,
-      Icons.work,           // Projets
+      Icons.work,           // Projets & Entreprises
       for (final p in plugins) p.iconData,
       Icons.notifications,
       Icons.library_books,
@@ -113,7 +113,7 @@ class _HomeScreenState extends State<HomeScreen> {
       'Calendrier',
       'Collaborateurs',
       'Messages',
-      'Projets',
+      'Projets & Entreprises',
       for (final p in plugins) p.displayName,
       'Notifications',
       'Library',


### PR DESCRIPTION
## Summary
- ajoute un `ProjectType` pour différencier projet simple et d'entreprise
- offre le choix du type lors de la création d'un projet
- met à jour les libellés en "Projets & Entreprises" dans la navigation et l'écran

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e8370934832984b63df81387b997