### PR TITLE
Adjust dashboard layout and project widget order

### DIFF
--- a/lib/features/dashboard/views/dashboard_screen.dart
+++ b/lib/features/dashboard/views/dashboard_screen.dart
@@ -38,6 +38,8 @@ class DashboardScreen extends StatelessWidget {
           const SizedBox(height: 16),
           // … vos autres widgets dashboard …
 
+          for (final w in dashboardProv.widgets) w,
+
           if (installedPlugins.isNotEmpty) ...[
             const Divider(height: 32),
             Text('Extensions installées', style: theme.textTheme.titleMedium),
@@ -46,8 +48,6 @@ class DashboardScreen extends StatelessWidget {
               if (p.buildDashboardWidget(context) != null)
                 p.buildDashboardWidget(context)!,
           ],
-
-          for (final w in dashboardProv.widgets) w,
         ],
       ),
     );

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -188,6 +188,7 @@ class _HomeScreenState extends State<HomeScreen> {
     Widget content = Scaffold(
       backgroundColor: isSequoia ? Colors.transparent : mainBg,
       body: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           sidebar,
           VerticalDivider(width: 1, color: dividerColor),


### PR DESCRIPTION
## Summary
- align main area to the top of the screen
- show dashboard widgets (including project progress) before plugin widgets

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e919b38c8329b96d9c664e9e4adf