### PR TITLE
Add sequoia background on auth pages

### DIFF
--- a/lib/features/auth/views/login_screen.dart
+++ b/lib/features/auth/views/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart'
 import 'package:firebase_auth/firebase_auth.dart';
 import 'register_screen.dart';
 import '../../../shared/interface/interface.dart'; // Ajuste le chemin si besoin
+import '../../../main.dart'; // Pour AppTheme et themeNotifier
 
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -89,8 +90,10 @@ class _LoginPageState extends State<LoginPage> {
       TargetPlatform.macOS,
     ].contains(defaultTargetPlatform);
 
-    return Scaffold(
-      backgroundColor: Colors.black,
+    final isSequoia = themeNotifier.value == AppTheme.sequoia;
+
+    Widget content = Scaffold(
+      backgroundColor: isSequoia ? Colors.transparent : Colors.black,
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(
@@ -203,6 +206,19 @@ class _LoginPageState extends State<LoginPage> {
         ),
       ),
     );
+
+    if (isSequoia) {
+      return Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage('assets/images/sequoia.jpeg'),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: content,
+      );
+    }
+    return content;
   }
 
   Widget _buildTextField({

--- a/lib/features/auth/views/register_screen.dart
+++ b/lib/features/auth/views/register_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 
 // 🔄 Redirection vers l’interface principale de Sequoia
 import '../../../shared/interface/interface.dart'; // ajuste le chemin si besoin
+import '../../../main.dart'; // Pour AppTheme et themeNotifier
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({Key? key}) : super(key: key);
@@ -54,8 +55,10 @@ class _RegisterPageState extends State<RegisterPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
+    final isSequoia = themeNotifier.value == AppTheme.sequoia;
+
+    Widget content = Scaffold(
+      backgroundColor: isSequoia ? Colors.transparent : Colors.black,
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(
@@ -201,6 +204,19 @@ class _RegisterPageState extends State<RegisterPage> {
         ),
       ),
     );
+
+    if (isSequoia) {
+      return Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage('assets/images/sequoia.jpeg'),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: content,
+      );
+    }
+    return content;
   }
 
   Widget _buildTextField({


### PR DESCRIPTION
## Summary
- show the Sequoia theme background on login and registration screens

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685342d25da88329a9225135de7be9ff