### PR TITLE
Fix projects screen syntax

### DIFF
--- a/lib/features/projects/views/projects_screen.dart
+++ b/lib/features/projects/views/projects_screen.dart
@@ -201,7 +201,6 @@ class ProjectsScreen extends StatelessWidget {
             ),
           ),
         ],
-        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- fix extra parenthesis in `ProjectsScreen`

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685344e903148329ab7f9f032f29ac67