### PR TITLE
Add profile info dialog after signup

### DIFF
--- a/lib/features/auth/widgets/profile_info_dialog.dart
+++ b/lib/features/auth/widgets/profile_info_dialog.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../plugins/crm/data/country_codes.dart';
+
+class ProfileInfoDialog extends StatefulWidget {
+  const ProfileInfoDialog({Key? key}) : super(key: key);
+
+  @override
+  State<ProfileInfoDialog> createState() => _ProfileInfoDialogState();
+}
+
+class _ProfileInfoDialogState extends State<ProfileInfoDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _firstNameCtrl = TextEditingController();
+  final _lastNameCtrl = TextEditingController();
+  final _phoneCtrl = TextEditingController();
+  String _dialCode = '+33';
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _firstNameCtrl.dispose();
+    _lastNameCtrl.dispose();
+    _phoneCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      await FirebaseFirestore.instance.collection('users').doc(uid).update({
+        'firstName': _firstNameCtrl.text.trim(),
+        'lastName': _lastNameCtrl.text.trim(),
+        'phoneNumber': '${_dialCode} ${_phoneCtrl.text.trim()}',
+      });
+    }
+    if (mounted) {
+      setState(() => _loading = false);
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Compléter votre profil'),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              controller: _firstNameCtrl,
+              decoration: const InputDecoration(labelText: 'Prénom'),
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? 'Champ requis' : null,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _lastNameCtrl,
+              decoration: const InputDecoration(labelText: 'Nom'),
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? 'Champ requis' : null,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: DropdownButtonFormField<String>(
+                    value: _dialCode,
+                    decoration: const InputDecoration(labelText: 'Indicatif'),
+                    items: [
+                      for (final c in countryCodes)
+                        DropdownMenuItem(
+                          value: c.dialCode,
+                          child: Text('${c.name} (${c.dialCode})'),
+                        ),
+                    ],
+                    onChanged: (val) =>
+                        setState(() => _dialCode = val ?? _dialCode),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  flex: 3,
+                  child: TextFormField(
+                    controller: _phoneCtrl,
+                    decoration: const InputDecoration(labelText: 'Téléphone'),
+                    keyboardType: TextInputType.phone,
+                    validator: (v) =>
+                        (v == null || v.trim().isEmpty) ? 'Champ requis' : null,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _loading ? null : _submit,
+          child: _loading
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Valider'),
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -17,6 +17,7 @@ import '../../features/projects/views/projects_screen.dart';
 import '../../settings/views/settings_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../features/auth/widgets/profile_info_dialog.dart';
 
 import '../../main.dart'; // Pour AppTheme, themeNotifier et AppColors
 import '../../features/notifications/services/notification_service.dart';
@@ -38,6 +39,29 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     _notifService.init();
+    _checkProfileCompletion();
+  }
+
+  Future<void> _checkProfileCompletion() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final doc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .get();
+    final data = doc.data() ?? {};
+    final first = (data['firstName'] ?? '').toString().trim();
+    final last = (data['lastName'] ?? '').toString().trim();
+    final phone = (data['phoneNumber'] ?? '').toString().trim();
+    if (first.isEmpty || last.isEmpty || phone.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => const ProfileInfoDialog(),
+        );
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- prompt user to fill in missing profile info on first login
- add profile info dialog for first name, last name and phone with dial code

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534a705f2c83298b43a0ce144a5df8