### PR TITLE
Fix sidebar reveal animation

### DIFF
--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -73,8 +73,18 @@ class _HomeScreenState extends State<HomeScreen> {
   void _toggleSidebar() {
     setState(() {
       _sidebarExpanded = !_sidebarExpanded;
-      _showLabels = _sidebarExpanded;
+      if (!_sidebarExpanded) {
+        _showLabels = false; // Hide labels immediately when collapsing
+      }
     });
+    if (_sidebarExpanded) {
+      // Delay showing labels until the expansion animation completes
+      Future.delayed(const Duration(milliseconds: 200), () {
+        if (mounted) {
+          setState(() => _showLabels = true);
+        }
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- fix sidebar label transition so labels show after the animation

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534cffed6c83298fe3c64968938df1