### PR TITLE
Keep sequoia background on auth pages

### DIFF
--- a/lib/features/auth/views/login_screen.dart
+++ b/lib/features/auth/views/login_screen.dart
@@ -84,16 +84,9 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
-    final isDesktop = [
-      TargetPlatform.windows,
-      TargetPlatform.linux,
-      TargetPlatform.macOS,
-    ].contains(defaultTargetPlatform);
-
-    final isSequoia = themeNotifier.value == AppTheme.sequoia;
 
     Widget content = Scaffold(
-      backgroundColor: isSequoia ? Colors.transparent : Colors.black,
+      backgroundColor: Colors.transparent,
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(
@@ -207,18 +200,15 @@ class _LoginPageState extends State<LoginPage> {
       ),
     );
 
-    if (isSequoia) {
-      return Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage('assets/images/sequoia.jpeg'),
-            fit: BoxFit.cover,
-          ),
+    return Container(
+      decoration: const BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage('assets/images/sequoia.jpeg'),
+          fit: BoxFit.cover,
         ),
-        child: content,
-      );
-    }
-    return content;
+      ),
+      child: content,
+    );
   }
 
   Widget _buildTextField({

--- a/lib/features/auth/views/register_screen.dart
+++ b/lib/features/auth/views/register_screen.dart
@@ -55,10 +55,8 @@ class _RegisterPageState extends State<RegisterPage> {
 
   @override
   Widget build(BuildContext context) {
-    final isSequoia = themeNotifier.value == AppTheme.sequoia;
-
     Widget content = Scaffold(
-      backgroundColor: isSequoia ? Colors.transparent : Colors.black,
+      backgroundColor: Colors.transparent,
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(
@@ -205,18 +203,15 @@ class _RegisterPageState extends State<RegisterPage> {
       ),
     );
 
-    if (isSequoia) {
-      return Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage('assets/images/sequoia.jpeg'),
-            fit: BoxFit.cover,
-          ),
+    return Container(
+      decoration: const BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage('assets/images/sequoia.jpeg'),
+          fit: BoxFit.cover,
         ),
-        child: content,
-      );
-    }
-    return content;
+      ),
+      child: content,
+    );
   }
 
   Widget _buildTextField({


### PR DESCRIPTION
## Summary
- keep login/register background image regardless of theme

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853594c0ba083299884d2bdfbc9404b