### PR TITLE
Modernize light theme colors

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -159,7 +159,7 @@ class _TasksPageState extends State<TasksPage> {
             showTaskPanel = true;
           });
         },
-        backgroundColor: AppColors.purple,
+        backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/features/tasks/widgets/task_list_mode_widget.dart
+++ b/lib/features/tasks/widgets/task_list_mode_widget.dart
@@ -59,7 +59,8 @@ class TasksListView extends StatelessWidget {
                 TextButton.icon(
                   onPressed: onAddTask,
                   style: TextButton.styleFrom(
-                    foregroundColor: AppColors.purple,
+                    foregroundColor:
+                        Theme.of(context).colorScheme.primary,
                   ),
                   icon: const Icon(Icons.add),
                   label: Text(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,26 +45,26 @@ final ThemeData lightTheme = ThemeData(
   brightness: Brightness.light,
   scaffoldBackgroundColor: Colors.white,
   colorScheme: const ColorScheme.light(
-    primary: AppColors.purple,
-    secondary: AppColors.blue,
+    primary: AppColors.blue,
+    secondary: AppColors.green,
     background: Colors.white,
     onBackground: Colors.black,
     onPrimary: Colors.white,
     onSecondary: Colors.white,
   ),
   appBarTheme: const AppBarTheme(
-    backgroundColor: AppColors.purple,
+    backgroundColor: AppColors.blue,
     foregroundColor: Colors.white,
   ),
   elevatedButtonTheme: ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
-      backgroundColor: AppColors.purple,
+      backgroundColor: AppColors.blue,
       foregroundColor: Colors.white,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     ),
   ),
   textButtonTheme: TextButtonThemeData(
-    style: TextButton.styleFrom(foregroundColor: AppColors.purple),
+    style: TextButton.styleFrom(foregroundColor: AppColors.blue),
   ),
   iconTheme: const IconThemeData(color: AppColors.blue),
   bottomNavigationBarTheme: const BottomNavigationBarThemeData(
@@ -98,7 +98,7 @@ final ThemeData darkTheme = ThemeData(
   scaffoldBackgroundColor: AppColors.darkBackground,
   colorScheme: const ColorScheme.dark(
     primary: AppColors.blue,
-    secondary: AppColors.purple,
+    secondary: AppColors.green,
     background: AppColors.darkBackground,
     surface: AppColors.darkBackground,
     onBackground: Colors.white,
@@ -117,7 +117,7 @@ final ThemeData darkTheme = ThemeData(
     ),
   ),
   textButtonTheme: TextButtonThemeData(
-    style: TextButton.styleFrom(foregroundColor: AppColors.purple),
+    style: TextButton.styleFrom(foregroundColor: AppColors.blue),
   ),
   iconTheme: const IconThemeData(color: AppColors.blue),
   bottomNavigationBarTheme: const BottomNavigationBarThemeData(

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -140,19 +140,6 @@ class _HomeScreenState extends State<HomeScreen> {
       Icons.settings,
     ];
 
-    // Couleurs des icônes (dans le même ordre)
-    final iconColors = <Color>[
-      Colors.black,
-      Colors.green,
-      Colors.orange,
-      Colors.purple,
-      Colors.blueGrey,
-      Colors.teal,
-      for (final _ in plugins) Colors.blueGrey,
-      Colors.red,
-      Colors.blue,
-      Colors.grey,
-    ];
 
     // Labels correspondantes
     final labels = <String>[
@@ -188,12 +175,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 index: i,
                 iconData: icons[i],
                 label: labels[i],
-                color: iconColors[i],
               )
                   : _buildNavItem(
                 iconData: icons[i],
                 label: labels[i],
-                color: iconColors[i],
                 showLabel: _showLabels,
                 isSelected: _selectedIndex == i,
                 onTap: () => setState(() => _selectedIndex = i),
@@ -206,12 +191,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 index: i,
                 iconData: icons[i],
                 label: labels[i],
-                color: iconColors[i],
               )
                   : _buildNavItem(
                 iconData: icons[i],
                 label: labels[i],
-                color: iconColors[i],
                 showLabel: _showLabels,
                 isSelected: _selectedIndex == i,
                 onTap: () => setState(() => _selectedIndex = i),
@@ -260,14 +243,12 @@ class _HomeScreenState extends State<HomeScreen> {
     required int index,
     required IconData iconData,
     required String label,
-    required Color color,
   }) {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) {
       return _buildNavItem(
         iconData: iconData,
         label: label,
-        color: color,
         showLabel: _showLabels,
         isSelected: _selectedIndex == index,
         onTap: () => setState(() => _selectedIndex = index),
@@ -292,7 +273,6 @@ class _HomeScreenState extends State<HomeScreen> {
         return _buildNavItem(
           iconData: iconData,
           label: label,
-          color: color,
           showLabel: _showLabels,
           isSelected: _selectedIndex == index,
           badgeCount: count > 0 ? count : null,
@@ -306,14 +286,12 @@ class _HomeScreenState extends State<HomeScreen> {
     required int index,
     required IconData iconData,
     required String label,
-    required Color color,
   }) {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) {
       return _buildNavItem(
         iconData: iconData,
         label: label,
-        color: color,
         showLabel: _showLabels,
         isSelected: _selectedIndex == index,
         onTap: () => setState(() => _selectedIndex = index),
@@ -343,7 +321,6 @@ class _HomeScreenState extends State<HomeScreen> {
             return _buildNavItem(
               iconData: iconData,
               label: label,
-              color: color,
               showLabel: _showLabels,
               isSelected: _selectedIndex == index,
               badgeCount: count > 0 ? count : null,
@@ -358,7 +335,6 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget _buildNavItem({
     required IconData iconData,
     required String label,
-    required Color color,
     required bool showLabel,
     required bool isSelected,
     required VoidCallback onTap,
@@ -367,7 +343,6 @@ class _HomeScreenState extends State<HomeScreen> {
     return _SidebarButton(
       iconData: iconData,
       label: label,
-      color: color,
       showLabel: showLabel,
       isSelected: isSelected,
       onTap: onTap,
@@ -379,7 +354,6 @@ class _HomeScreenState extends State<HomeScreen> {
 class _SidebarButton extends StatefulWidget {
   final IconData iconData;
   final String label;
-  final Color color;
   final bool showLabel;
   final bool isSelected;
   final VoidCallback onTap;
@@ -389,7 +363,6 @@ class _SidebarButton extends StatefulWidget {
     Key? key,
     required this.iconData,
     required this.label,
-    required this.color,
     required this.showLabel,
     required this.isSelected,
     required this.onTap,
@@ -405,9 +378,10 @@ class _SidebarButtonState extends State<_SidebarButton> {
 
   @override
   Widget build(BuildContext context) {
-    final normalColor = widget.color.withOpacity(0.6);
-    final hoverColor = widget.color;
-    final selectedColor = widget.color;
+    final colorScheme = Theme.of(context).colorScheme;
+    final normalColor = colorScheme.onSurface.withOpacity(0.6);
+    final hoverColor = colorScheme.onSurface;
+    final selectedColor = colorScheme.primary;
     const hoverBg = Color(0xFFE5E5EA);
     const selectedBg = Color(0xFFE5E5EA);
 


### PR DESCRIPTION
## Summary
- modernize sidebar interface style
- switch primary colors from purple to blue
- update tasks views to use theme primary color

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535b1574488329977dcd5688997164