### PR TITLE
Round menu SVG icons

### DIFF
--- a/assets/icons/calendar.svg
+++ b/assets/icons/calendar.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#F39C12"/>
-  <rect x="5" y="6" width="14" height="13" rx="2" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="24" height="24" rx="8" fill="#F39C12"/>
+  <rect x="5" y="6" width="14" height="13" rx="4" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <line x1="5" y1="10" x2="19" y2="10" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <line x1="9" y1="4" x2="9" y2="6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <line x1="15" y1="4" x2="15" y2="6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/assets/icons/collaborators.svg
+++ b/assets/icons/collaborators.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#3498DB"/>
+  <rect width="24" height="24" rx="8" fill="#3498DB"/>
   <circle cx="9" cy="9" r="3" fill="none" stroke="white" stroke-width="2"/>
   <circle cx="15" cy="9" r="3" fill="none" stroke="white" stroke-width="2"/>
   <path d="M4 20v-1a4 4 0 014-4h8a4 4 0 014 4v1" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/assets/icons/dashboard.svg
+++ b/assets/icons/dashboard.svg
@@ -1,7 +1,7 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#1ABC9C"/>
-  <rect x="5" y="5" width="6" height="6" rx="1" fill="white"/>
-  <rect x="13" y="5" width="6" height="6" rx="1" fill="white"/>
-  <rect x="5" y="13" width="6" height="6" rx="1" fill="white"/>
-  <rect x="13" y="13" width="6" height="6" rx="1" fill="white"/>
+  <rect width="24" height="24" rx="8" fill="#1ABC9C"/>
+  <rect x="5" y="5" width="6" height="6" rx="2" fill="white"/>
+  <rect x="13" y="5" width="6" height="6" rx="2" fill="white"/>
+  <rect x="5" y="13" width="6" height="6" rx="2" fill="white"/>
+  <rect x="13" y="13" width="6" height="6" rx="2" fill="white"/>
 </svg>

--- a/assets/icons/messages.svg
+++ b/assets/icons/messages.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#9B59B6"/>
+  <rect width="24" height="24" rx="8" fill="#9B59B6"/>
   <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/assets/icons/projects.svg
+++ b/assets/icons/projects.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#E67E22"/>
-  <rect x="4" y="6" width="16" height="12" rx="2" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="24" height="24" rx="8" fill="#E67E22"/>
+  <rect x="4" y="6" width="16" height="12" rx="4" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <line x1="4" y1="9" x2="20" y2="9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- make the sidebar icons rounder by increasing the corner radius

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685366c0e3c883298b463b1616e46f47