### PR TITLE
Add left spacing in sidebar

### DIFF
--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -229,6 +229,7 @@ class _HomeScreenState extends State<HomeScreen> {
       body: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          const SizedBox(width: 1),
           sidebar,
           VerticalDivider(width: 1, color: dividerColor),
           Expanded(child: pages[_selectedIndex]),


### PR DESCRIPTION
## Summary
- add a small sized box before the sidebar so there is space between the icons and the screen edge

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536717d64c83298b3b39ca1bda83ca