### PR TITLE
Fix tasks.svg checkmark path spacing

### DIFF
--- a/assets/icons/tasks.svg
+++ b/assets/icons/tasks.svg
@@ -1,3 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <path d="M7 12l3 3 7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="24" height="24" rx="4" fill="#1ABC9C"/>
+  <path d="M7 12l3 3 7 -7" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- correct tasks icon with teal background and white checkmark

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853688a47908329b0a89b4ae4675c6a