### PR TITLE
Add customizable background image

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,10 @@ enum AppTheme { light, dark, sequoia }
 /// 2) ValueNotifier global, initialisé à Clair (sera écrasé si prefs contient autre chose)
 final ValueNotifier<AppTheme> themeNotifier = ValueNotifier(AppTheme.light);
 
+/// Image de fond configurable
+final ValueNotifier<String> backgroundImageNotifier =
+    ValueNotifier('assets/images/backgroundimage.jpeg');
+
 /// 3) Classe centralisant toutes les couleurs utilisées dans l’app
 class AppColors {
   static const Color darkBackground      = Color(0xFF212121);
@@ -195,6 +199,14 @@ Future<void> main() async {
           (e) => e.toString() == stored,
       orElse: () => AppTheme.light,
     );
+  }
+
+  // Charger l'image de fond sauvegardée
+  final storedBg = prefs.getString('backgroundImage');
+  if (storedBg != null) {
+    backgroundImageNotifier.value = storedBg;
+  } else if (themeNotifier.value == AppTheme.sequoia) {
+    backgroundImageNotifier.value = 'assets/images/sequoia.jpeg';
   }
 
   runApp(

--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -19,12 +19,14 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   late AppTheme _selectedTheme;
+  late String _selectedBgImage;
 
   @override
   void initState() {
     super.initState();
     // Récupère l’état actuel du themeNotifier
     _selectedTheme = themeNotifier.value;
+    _selectedBgImage = backgroundImageNotifier.value;
   }
 
   /// Sauvegarde et applique le thème sélectionné
@@ -36,6 +38,17 @@ class _SettingsPageState extends State<SettingsPage> {
     });
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('appTheme', newTheme.toString());
+  }
+
+  /// Sauvegarde et applique l'image de fond sélectionnée
+  Future<void> _onBgImageChanged(String? newImage) async {
+    if (newImage == null) return;
+    setState(() {
+      _selectedBgImage = newImage;
+      backgroundImageNotifier.value = newImage;
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('backgroundImage', newImage);
   }
 
   Future<void> _signOut(BuildContext context) async {
@@ -113,12 +126,45 @@ class _SettingsPageState extends State<SettingsPage> {
                         child: Text('Sequoia'),
                       ),
                     ],
-                    onChanged: _onThemeChanged,
-                  ),
-                ),
-              ],
+                onChanged: _onThemeChanged,
+              ),
             ),
-          ),
+          ],
+        ),
+      ),
+
+      const SizedBox(height: 8),
+      Container(
+        decoration: BoxDecoration(
+          color: tileBgColor,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: Row(
+          children: [
+            Icon(Icons.image, color: accentColor),
+            const SizedBox(width: 12),
+            Expanded(
+              child: DropdownButton<String>(
+                isExpanded: true,
+                value: _selectedBgImage,
+                underline: const SizedBox(),
+                items: const [
+                  DropdownMenuItem(
+                    value: 'assets/images/backgroundimage.jpeg',
+                    child: Text('Par d\'efaut'),
+                  ),
+                  DropdownMenuItem(
+                    value: 'assets/images/sequoia.jpeg',
+                    child: Text('Sequoia'),
+                  ),
+                ],
+                onChanged: _onBgImageChanged,
+              ),
+            ),
+          ],
+        ),
+      ),
 
           const SizedBox(height: 16),
           const Divider(color: Colors.white24),

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -236,18 +236,20 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
     );
 
-    if (isSequoia) {
-      return Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage('assets/images/sequoia.jpeg'),
-            fit: BoxFit.cover,
+    return ValueListenableBuilder<String>(
+      valueListenable: backgroundImageNotifier,
+      builder: (context, bgImage, _) {
+        return Container(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: AssetImage(bgImage),
+              fit: BoxFit.cover,
+            ),
           ),
-        ),
-        child: content,
-      );
-    }
-    return content;
+          child: content,
+        );
+      },
+    );
   }
 
   Widget _buildMessagesNavItem({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ flutter:
   assets:
     - assets/images/tokan.svg
     - assets/images/sequoia.jpeg
+    - assets/images/backgroundimage.jpeg
     - assets/icons/dashboard.svg
     - assets/icons/tasks.svg
     - assets/icons/calendar.svg


### PR DESCRIPTION
## Summary
- add customizable background image preference and dropdown in settings
- load saved image or default to theme-based background
- always show Sequoia image on login/register pages
- remove bundled image file from repo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536c6000d08329836b7969be5847db