### PR TITLE
Fix background handling for light theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,10 @@ class AppColors {
 /// 4) Définition du thème clair
 final ThemeData lightTheme = ThemeData(
   brightness: Brightness.light,
-  scaffoldBackgroundColor: Colors.white,
+  // Use a transparent scaffold background so the optional background image
+  // remains visible. Widgets will therefore have transparent backgrounds
+  // unless otherwise specified.
+  scaffoldBackgroundColor: Colors.transparent,
   colorScheme: const ColorScheme.light(
     primary: AppColors.blue,
     secondary: AppColors.green,

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -239,8 +239,12 @@ class _HomeScreenState extends State<HomeScreen> {
     return ValueListenableBuilder<String>(
       valueListenable: backgroundImageNotifier,
       builder: (context, bgImage, _) {
+        final isLight = themeNotifier.value == AppTheme.light;
         return Container(
           decoration: BoxDecoration(
+            // Provide a white fallback when no background image is set in
+            // light mode, keeping other themes unchanged.
+            color: isLight ? Colors.white : null,
             image: DecorationImage(
               image: AssetImage(bgImage),
               fit: BoxFit.cover,


### PR DESCRIPTION
## Summary
- allow background image to be visible in light theme by making the scaffold background transparent
- in `HomeScreen` add a white fallback when no image is used

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685373502ed8832999e012612a66e70e