### PR TITLE
Fix divider color in settings page

### DIFF
--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -181,7 +181,9 @@ class _SettingsPageState extends State<SettingsPage> {
       ],
 
           const SizedBox(height: 16),
-          const Divider(color: Colors.white24),
+          Divider(
+            color: isDarkStyle ? Colors.white24 : Colors.grey.shade800,
+          ),
 
           // SECTION « Compte »
           Text(
@@ -216,7 +218,9 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
 
           const SizedBox(height: 16),
-          const Divider(color: Colors.white24),
+          Divider(
+            color: isDarkStyle ? Colors.white24 : Colors.grey.shade800,
+          ),
 
           // SECTION « À propos »
           Text(


### PR DESCRIPTION
## Summary
- improve settings divider visibility in light mode

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537985c6b483299dffaf69d97ddeaf