### PR TITLE
Fix light theme background image

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ final ValueNotifier<AppTheme> themeNotifier = ValueNotifier(AppTheme.light);
 
 /// Image de fond configurable
 final ValueNotifier<String> backgroundImageNotifier =
-    ValueNotifier('assets/images/backgroundimage.jpeg');
+    ValueNotifier('assets/images/sequoia.jpeg');
 
 /// 3) Classe centralisant toutes les couleurs utilisées dans l’app
 class AppColors {
@@ -210,7 +210,7 @@ Future<void> main() async {
     backgroundImageNotifier.value = 'assets/images/sequoia.jpeg';
   } else {
     backgroundImageNotifier.value =
-        storedBg ?? 'assets/images/backgroundimage.jpeg';
+        storedBg ?? 'assets/images/sequoia.jpeg';
   }
 
   runApp(

--- a/lib/settings/views/settings_screen.dart
+++ b/lib/settings/views/settings_screen.dart
@@ -43,11 +43,11 @@ class _SettingsPageState extends State<SettingsPage> {
       backgroundImageNotifier.value = 'assets/images/sequoia.jpeg';
     } else if (newTheme == AppTheme.light) {
       final bg =
-          prefs.getString('backgroundImage') ?? 'assets/images/backgroundimage.jpeg';
+          prefs.getString('backgroundImage') ?? 'assets/images/sequoia.jpeg';
       backgroundImageNotifier.value = bg;
       setState(() => _selectedBgImage = bg);
     } else {
-      backgroundImageNotifier.value = 'assets/images/backgroundimage.jpeg';
+      backgroundImageNotifier.value = 'assets/images/sequoia.jpeg';
     }
   }
 
@@ -164,7 +164,7 @@ class _SettingsPageState extends State<SettingsPage> {
                   underline: const SizedBox(),
                   items: const [
                     DropdownMenuItem(
-                      value: 'assets/images/backgroundimage.jpeg',
+                      value: 'assets/images/sequoia.jpeg',
                       child: Text('Par d\'efaut'),
                     ),
                     DropdownMenuItem(

--- a/lib/shared/interface/interface.dart
+++ b/lib/shared/interface/interface.dart
@@ -92,6 +92,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isSequoia = themeNotifier.value == AppTheme.sequoia;
+    final isLight = themeNotifier.value == AppTheme.light;
     final pluginProv = context.watch<PluginProvider>();
 
     // 1) Pages "de base"
@@ -225,7 +226,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
 
     Widget content = Scaffold(
-      backgroundColor: isSequoia ? Colors.transparent : mainBg,
+      backgroundColor: (isSequoia || isLight) ? Colors.transparent : mainBg,
       body: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,6 @@ flutter:
   assets:
     - assets/images/tokan.svg
     - assets/images/sequoia.jpeg
-    - assets/images/backgroundimage.jpeg
     - assets/icons/dashboard.svg
     - assets/icons/tasks.svg
     - assets/icons/calendar.svg


### PR DESCRIPTION
## Summary
- avoid white overlay so the light theme background stays visible
- remove duplicate background image and point to existing asset

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853748b2cbc8329bfb54cfd88958d13