### PR TITLE
Fix header background on tasks screen

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -92,9 +92,7 @@ class _TasksPageState extends State<TasksPage> {
                 children: [
                   // Menu horizontal avec fond "glass header"
                   Container(
-                    color: isLight
-                        ? AppColors.whiteGlassHeader
-                        : AppColors.glassHeader,
+                    color: AppColors.glassHeader,
                     child: _buildHorizontalMenu(tasks),
                   ),
                   Expanded(child: _buildView(tasks)),


### PR DESCRIPTION
## Summary
- keep the tasks screen header consistent with other pages

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d5eb1a6c8329bd69a32d985529f6