### PR TITLE
Remove white background in tasks list

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -44,12 +44,9 @@ class _TasksPageState extends State<TasksPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isLight = themeNotifier.value == AppTheme.light;
 
     return Scaffold(
-      backgroundColor: isLight
-          ? AppColors.whiteGlassBackground
-          : theme.scaffoldBackgroundColor,
+      backgroundColor: theme.scaffoldBackgroundColor,
       body: Stack(
         children: [
           if (_multiSelectMode)


### PR DESCRIPTION
## Summary
- remove `AppColors.whiteGlassBackground` so the tasks list uses the default scaffold background

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e70b53248329a9f355d350034b86