### PR TITLE
Remove header background in light theme

### DIFF
--- a/lib/features/tasks/views/tasks_screen.dart
+++ b/lib/features/tasks/views/tasks_screen.dart
@@ -92,7 +92,8 @@ class _TasksPageState extends State<TasksPage> {
                 children: [
                   // Menu horizontal avec fond "glass header"
                   Container(
-                    color: AppColors.glassHeader,
+                    color:
+                        isLight ? Colors.transparent : AppColors.glassHeader,
                     child: _buildHorizontalMenu(tasks),
                   ),
                   Expanded(child: _buildView(tasks)),


### PR DESCRIPTION
## Summary
- keep task screen header transparent in light theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e7169c8c8329ad17d0befa145c40